### PR TITLE
Relax payout approval chat checks

### DIFF
--- a/app/handlers/admin/payout_actions.py
+++ b/app/handlers/admin/payout_actions.py
@@ -110,7 +110,7 @@ async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             await context.bot.send_message(chat_id=user_id, text=user_message)
         except BadRequest as e:
             log(f"❌ Failed to send message to chat {user_id} — {e}")
-            raise
+            # Do not interrupt the payout process if user notification fails
     else:
         log(f"⚠️ Skipping message — invalid or fake user_id: {user_id}")
 
@@ -125,7 +125,7 @@ async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         log(
             f"❌ Failed to edit message {query.message.message_id} in chat {query.message.chat.id} — {e}"
         )
-        raise
+        # Editing message is optional; continue without raising
 
     if request_to_approve["method"] == "💳 На карту":
         cashier_text = (
@@ -159,7 +159,7 @@ async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             )
         except BadRequest as e:
             log(f"❌ Failed to send message to chat {CARD_DISPATCH_CHAT_ID} — {e}")
-            raise
+            # Continue even if the cashier chat is missing
         except Exception as e:
             log(f"❌ [allow_payout] Ошибка отправки кассиру: {e}")
 


### PR DESCRIPTION
## Summary
- avoid interrupting payout approval when user notification fails
- tolerate errors while editing approval messages
- proceed even if cashier chat is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fa1ab7d048329a8d000a40d0014b0