### PR TITLE
Add payout request button for users

### DIFF
--- a/app/keyboards/reply_user.py
+++ b/app/keyboards/reply_user.py
@@ -8,6 +8,7 @@ def get_main_menu() -> ReplyKeyboardMarkup:
     """
     keyboard: List[List[str]] = [
         ["📄 Просмотр ЗП"],
+        ["💰 Запросить выплату"],
         ["📅 Просмотр расписания", "👤 Личный кабинет"],
     ]
     return ReplyKeyboardMarkup(
@@ -37,7 +38,8 @@ def get_cabinet_menu() -> ReplyKeyboardMarkup:
     """
     keyboard: List[List[str]] = [
         ["📋 Мои данные", "✏️ Изменить данные"],
-        ["📜 История запросов", "🏠 Домой"],
+        ["💰 Запросить выплату", "📜 История запросов"],
+        ["🏠 Домой"],
     ]
     return ReplyKeyboardMarkup(
         keyboard, resize_keyboard=True, one_time_keyboard=False


### PR DESCRIPTION
## Summary
- update user reply keyboards
  - add "💰 Запросить выплату" option to main menu
  - add same option in personal cabinet menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687185ceab188329bffce632b51f4040