### PR TITLE
Enable payout request conversation

### DIFF
--- a/app/core/application.py
+++ b/app/core/application.py
@@ -11,6 +11,7 @@ from ..utils.logger import log
 from .conversations import (
     build_admin_conversation,
     build_manual_payout_conversation,
+    build_payout_conversation,
 )
 from ..handlers.user import (
     handle_salary_request,
@@ -65,6 +66,7 @@ def create_application():
 def _register_all_handlers(app):
     admin_conv_handler = build_admin_conversation()
     manual_payout_handler = build_manual_payout_conversation()
+    payout_conv_handler = build_payout_conversation()
     reset_filter = filters.Regex(r"^(🏠 Домой|🔙 Назад|❌ Отмена)$")
     app.add_handler(CommandHandler("start", start))
     app.add_handler(
@@ -77,6 +79,7 @@ def _register_all_handlers(app):
     )
     app.add_handler(admin_conv_handler)
     app.add_handler(manual_payout_handler)
+    app.add_handler(payout_conv_handler)
     app.add_handler(CallbackQueryHandler(allow_payout, pattern=r"^allow_payout_"))
     app.add_handler(CallbackQueryHandler(deny_payout, pattern=r"^deny_payout_"))
     app.add_handler(

--- a/app/core/conversations.py
+++ b/app/core/conversations.py
@@ -10,6 +10,8 @@ from ..constants import (
     UserStates,
     AdvanceReportStates,
     ManualPayoutStates,
+    PayoutStates,
+    PAYMENT_REQUEST_PATTERN,
 )
 from ..config import ADMIN_ID
 from ..handlers.user import (
@@ -17,6 +19,13 @@ from ..handlers.user import (
     view_salary_user,
     view_schedule_user,
     personal_cabinet,
+)
+from ..handlers.user.payout import (
+    request_payout_start,
+    select_type,
+    enter_amount,
+    select_method,
+    confirm_card,
 )
 from ..handlers.admin import (
     admin,
@@ -163,7 +172,34 @@ def build_manual_payout_conversation():
     )
 
 
+def build_payout_conversation():
+    return ConversationHandler(
+        entry_points=[
+            MessageHandler(filters.Regex(PAYMENT_REQUEST_PATTERN), request_payout_start)
+        ],
+        states={
+            PayoutStates.SELECT_TYPE: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, select_type)
+            ],
+            PayoutStates.ENTER_AMOUNT: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, enter_amount)
+            ],
+            PayoutStates.SELECT_METHOD: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, select_method)
+            ],
+            PayoutStates.CONFIRM_CARD: [
+                CallbackQueryHandler(confirm_card, pattern="^payout_")
+            ],
+        },
+        fallbacks=[
+            MessageHandler(filters.Regex(r"^(🏠 Домой|Назад|Отмена)$"), global_reset)
+        ],
+        per_message=True,
+    )
+
+
 __all__ = [
     "build_admin_conversation",
     "build_manual_payout_conversation",
+    "build_payout_conversation",
 ]


### PR DESCRIPTION
## Summary
- wire payout request handlers into a new `build_payout_conversation`
- register this conversation so users can request payouts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68718813fcc48329a9470805a7343ffa