### PR TITLE
Fix FSM configuration

### DIFF
--- a/app/core/conversations.py
+++ b/app/core/conversations.py
@@ -139,7 +139,7 @@ def build_admin_conversation():
             MessageHandler(filters.Regex(r"^(🏠 Домой|Назад|Отмена)$"), global_reset),
             CommandHandler("cancel", cancel_payouts),
         ],
-        per_message=True,
+        per_chat=True,
     )
 
 
@@ -168,7 +168,7 @@ def build_manual_payout_conversation():
         fallbacks=[
             MessageHandler(filters.Regex(r"^(🏠 Домой|Назад|Отмена)$"), global_reset)
         ],
-        per_message=True,
+        per_chat=True,
     )
 
 
@@ -194,7 +194,7 @@ def build_payout_conversation():
         fallbacks=[
             MessageHandler(filters.Regex(r"^(🏠 Домой|Назад|Отмена)$"), global_reset)
         ],
-        per_message=True,
+        per_chat=True,
     )
 
 


### PR DESCRIPTION
## Summary
- fix ConversationHandler configuration by replacing `per_message=True` with `per_chat=True`

## Testing
- `pytest -q`
- `python -m app.main` *(fails: AttributeError: 'NoneType' object has no attribute 'run_daily')*

------
https://chatgpt.com/codex/tasks/task_e_6873d3a5da248329bd91c80e26128fec