### PR TITLE
Fix home button role check

### DIFF
--- a/app/handlers/admin/menu.py
+++ b/app/handlers/admin/menu.py
@@ -3,7 +3,8 @@ from telegram import Update
 from telegram.ext import ContextTypes, ConversationHandler
 from ...constants import UserStates
 from ...config import ADMIN_ID
-from ...keyboards.reply_admin import get_admin_menu
+from ...keyboards.reply_admin import get_admin_menu, send_admin_menu
+from ...keyboards.reply_user import send_user_menu
 from ...utils.logger import log
 
 # Глобальная переменная для режима администратора
@@ -36,9 +37,11 @@ async def home_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     log(
         f"DEBUG [home_callback] Сброс состояний для user_id: {update.effective_user.id}"
     )
-    await update.message.reply_text(
-        "🏠 Главное меню", reply_markup=get_admin_menu()
-    )
+    user_id = update.effective_user.id
+    if user_id == ADMIN_ID:
+        await send_admin_menu(update, context)
+    else:
+        await send_user_menu(update, context)
     return ConversationHandler.END
 
 

--- a/app/keyboards/reply_admin.py
+++ b/app/keyboards/reply_admin.py
@@ -1,4 +1,5 @@
-from telegram import ReplyKeyboardMarkup
+from telegram import ReplyKeyboardMarkup, Update
+from telegram.ext import ContextTypes
 from typing import List
 
 
@@ -49,3 +50,8 @@ def get_confirmation_keyboard() -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(
         keyboard, resize_keyboard=True, one_time_keyboard=False
     )
+
+
+async def send_admin_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send the main admin menu."""
+    await update.message.reply_text("🏠 Главное меню", reply_markup=get_admin_menu())

--- a/app/keyboards/reply_user.py
+++ b/app/keyboards/reply_user.py
@@ -1,4 +1,5 @@
-from telegram import ReplyKeyboardMarkup
+from telegram import ReplyKeyboardMarkup, Update
+from telegram.ext import ContextTypes
 from typing import List
 
 
@@ -50,4 +51,11 @@ def get_edit_keyboard():
     keyboard = [["📱 Изменить телефон"], ["🏦 Изменить банк"], ["🏠 Домой"]]
     return ReplyKeyboardMarkup(
         keyboard, resize_keyboard=True, one_time_keyboard=True
+    )
+
+
+async def send_user_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send the main user menu."""
+    await update.message.reply_text(
+        "🏠 Вы вернулись в главное меню.", reply_markup=get_main_menu()
     )


### PR DESCRIPTION
## Summary
- add `send_admin_menu` and `send_user_menu` helpers
- return user or admin menu in `home_callback`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e5a435ec8329b758c0fbce62215b