### PR TITLE
Fix broadcast confirmation state

### DIFF
--- a/app/core/conversations.py
+++ b/app/core/conversations.py
@@ -134,6 +134,9 @@ def build_admin_conversation():
                 MessageHandler(filters.Regex("^🏠 Домой$"), home_callback),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, handle_broadcast_message),
             ],
+            UserStates.BROADCAST_CONFIRM: [
+                CallbackQueryHandler(handle_broadcast_confirm),
+            ],
         },
         fallbacks=[
             MessageHandler(filters.Regex(r"^(🏠 Домой|Назад|Отмена)$"), global_reset),


### PR DESCRIPTION
## Summary
- add missing BROADCAST_CONFIRM handler to admin FSM so the broadcast flow works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873eb3671708329a89381fe181744eb