### PR TITLE
Implement message history and employee selector

### DIFF
--- a/admin_frontend/src/pages/Broadcast.jsx
+++ b/admin_frontend/src/pages/Broadcast.jsx
@@ -4,7 +4,8 @@ import api from '../api';
 
 export default function Broadcast() {
   const [message, setMessage] = useState('');
-  const [chatId, setChatId] = useState('');
+  const [employees, setEmployees] = useState([]);
+  const [selected, setSelected] = useState([]);
   const [templates, setTemplates] = useState([]);
   const [selectedTpl, setSelectedTpl] = useState('');
   const [status, setStatus] = useState('active');
@@ -13,9 +14,10 @@ export default function Broadcast() {
     const saved = localStorage.getItem('broadcast_draft');
     if (saved) setMessage(saved);
     api.get('messages/templates').then(r => setTemplates(r.data));
+    api.get('employees/').then(r => setEmployees(r.data));
     window.refreshPage = () => {
       setMessage('');
-      setChatId('');
+      setSelected([]);
     };
   }, []);
 
@@ -30,7 +32,7 @@ export default function Broadcast() {
       await api.post('telegram/broadcast', {
         message,
         status,
-        test_user_id: mode === 'test' ? chatId : undefined,
+        test_user_id: mode === 'test' ? selected[0] : undefined,
       });
       setMessage('');
     } catch (err) {
@@ -39,17 +41,20 @@ export default function Broadcast() {
   }
 
   async function sendOne() {
-    if (!message.trim() || !chatId.trim()) return;
-    try {
-      await api.post('telegram/send_message', {
-        user_id: chatId,
-        message,
-        require_ack: true,
-      });
-      setMessage('');
-    } catch (err) {
-      console.error(err);
+    if (!message.trim() || selected.length === 0) return;
+    for (const id of selected) {
+      try {
+        await api.post('telegram/send_message', {
+          user_id: id,
+          message,
+          require_ack: true,
+        });
+      } catch (err) {
+        console.error(err);
+      }
     }
+    setMessage('');
+    setSelected([]);
   }
 
   return (
@@ -88,18 +93,26 @@ export default function Broadcast() {
           <Send size={16} /> Отправить всем
         </button>
 
-        <input
+        <select
+          multiple
           className="flex-1 min-w-[180px] border border-gray-300 rounded px-3 py-2 shadow-sm focus:outline-none"
-          placeholder="Chat ID получателя"
-          value={chatId}
-          onChange={(e) => setChatId(e.target.value)}
-        />
+          value={selected}
+          onChange={(e) =>
+            setSelected(Array.from(e.target.selectedOptions).map((o) => o.value))
+          }
+        >
+          {employees.map((e) => (
+            <option key={e.id} value={e.id}>
+              {e.full_name || e.name}
+            </option>
+          ))}
+        </select>
 
         <button
           onClick={sendOne}
           className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded shadow hover:bg-green-700"
         >
-          <User size={16} /> Отправить одному
+          <User size={16} /> Отправить выбранным
         </button>
 
         <button

--- a/admin_frontend/src/pages/Payouts.jsx
+++ b/admin_frontend/src/pages/Payouts.jsx
@@ -9,6 +9,99 @@ import {
 } from 'lucide-react';
 import api from '../api';
 
+function MessageHistory() {
+  const [list, setList] = useState([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      const res = await api.get('telegram/sent_messages');
+      setList(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function remove(id) {
+    if (!window.confirm('Удалить запись?')) return;
+    await api.delete(`telegram/sent_messages/${id}`);
+    load();
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold">История сообщений</h3>
+      <div className="overflow-auto border rounded">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-2 py-1 text-left">Получатель</th>
+              <th className="px-2 py-1 text-left">Сообщение</th>
+              <th className="px-2 py-1 text-left">Дата</th>
+              <th className="px-2 py-1"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {list.map((m) => (
+              m.broadcast ? (
+                <tr key={m.id}>
+                  <td colSpan="4" className="px-2 py-1">
+                    <details>
+                      <summary className="cursor-pointer text-blue-600">
+                        Массовая рассылка
+                      </summary>
+                      <ul className="ml-4 list-disc">
+                        {m.recipients?.map((r) => (
+                          <li key={r.user_id}>{r.name} - {r.status}</li>
+                        ))}
+                      </ul>
+                      <div className="text-xs text-gray-500 mt-1">
+                        {m.timestamp && new Date(m.timestamp).toLocaleString()}
+                      </div>
+                    </details>
+                    <button
+                      onClick={() => remove(m.id)}
+                      className="text-red-600 text-sm"
+                    >
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+              ) : (
+                <tr key={m.id}>
+                  <td className="px-2 py-1">{m.user_id}</td>
+                  <td className="px-2 py-1 whitespace-pre-wrap">{m.message}</td>
+                  <td className="px-2 py-1 text-xs">
+                    {m.timestamp && new Date(m.timestamp).toLocaleString()}
+                  </td>
+                  <td className="px-2 py-1">
+                    <button
+                      onClick={() => remove(m.id)}
+                      className="text-red-600 text-sm"
+                    >
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+              )
+            ))}
+            {list.length === 0 && (
+              <tr>
+                <td colSpan="4" className="px-2 py-2 text-center text-gray-500">
+                  Нет данных
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 const MAX_AMOUNT = 100000;
 const STATUS_OPTIONS = ['Ожидает', 'Одобрено', 'Отклонено', 'Выплачено'];
 
@@ -478,6 +571,8 @@ export default function Payouts() {
       </div>
 
       <Summary list={payouts} />
+
+      <MessageHistory />
 
       {showEditor && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">

--- a/app/api/telegram.py
+++ b/app/api/telegram.py
@@ -55,4 +55,9 @@ def create_telegram_router(repo: EmployeeRepository) -> APIRouter:
     async def sent_messages() -> list[SentMessage]:
         return [SentMessage(**m) for m in service._load_log()]
 
+    @router.delete("/sent_messages/{entry_id}")
+    async def delete_sent_message(entry_id: str):
+        service.delete_log_entry(entry_id)
+        return {"status": "deleted"}
+
     return router

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -34,10 +34,13 @@ class BroadcastRequest(BaseModel):
 
 
 class SentMessage(BaseModel):
-    user_id: str
+    id: str
+    user_id: Optional[str] = None
     message: str
     status: str
-    message_id: int
+    message_id: Optional[int] = None
     timestamp: str
     photo_url: Optional[str] = None
     requires_ack: bool = False
+    broadcast: bool = False
+    recipients: Optional[list[dict]] = None

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Sequence, List, Dict, Any
 from datetime import datetime
+from uuid import uuid4
 
 from telegram import Bot
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -40,24 +41,31 @@ class TelegramService:
         if not ADMIN_CHAT_ID:
             log("⚠️ ADMIN_CHAT_ID not configured")
 
-    def _load_log(self) -> List[Dict]:
-        """Return log records sorted by timestamp descending."""
+    def _load_log_all(self) -> List[Dict]:
         try:
             data = json.loads(self.msg_log.read_text(encoding="utf-8"))
         except Exception:
             return []
+        return data
+
+    def _load_log(self) -> List[Dict]:
+        """Return log records sorted by timestamp descending."""
+        data = self._load_log_all()
         return sorted(
             data,
-            key=lambda x: x.get(
-                "timestamp",
-                ""),
-            reverse=True)[
-            :50]
+            key=lambda x: x.get("timestamp", ""),
+            reverse=True,
+        )[:50]
 
     def _save_log(self, data: List[Dict]) -> None:
         self.msg_log.write_text(
             json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
         )
+
+    def delete_log_entry(self, entry_id: str) -> None:
+        data = self._load_log_all()
+        data = [d for d in data if str(d.get("id")) != str(entry_id)]
+        self._save_log(data)
 
     @classmethod
     def update_sent_message_status(
@@ -94,6 +102,7 @@ class TelegramService:
         if test_user_id:
             employees = [e for e in employees if str(e.id) == str(test_user_id)]
         success = 0
+        recipients: List[Dict[str, Any]] = []
         for emp in employees:
             if not is_valid_user_id(emp.id):
                 log(f"⚠️ Skipping message — invalid or fake user_id: {emp.id}")
@@ -118,11 +127,26 @@ class TelegramService:
                     )
                 success += 1
                 logger.info(f"Sent to {emp.id}")
+                recipients.append({
+                    "user_id": str(emp.id),
+                    "name": emp.full_name or emp.name,
+                    "status": "отправлено",
+                })
             except BadRequest as exc:
                 log(f"❌ Failed to send broadcast to chat {emp.id} — {exc}")
                 raise
             except Exception as exc:
                 logger.warning(f"Failed for {emp.id}: {exc}")
+        log_entry = {
+            "id": str(uuid4()),
+            "broadcast": True,
+            "message": message,
+            "timestamp": datetime.utcnow().isoformat(),
+            "recipients": recipients,
+        }
+        data = self._load_log_all()
+        data.append(log_entry)
+        self._save_log(data)
         return {"success": True, "sent": success, "total": len(employees)}
 
     async def send_message_to_user(
@@ -164,6 +188,7 @@ class TelegramService:
             log(f"❌ Failed to send message to chat {user_id} — {exc}")
             raise
         log_entry = {
+            "id": str(uuid4()),
             "user_id": str(user_id),
             "message": message,
             "status": "отправлено",
@@ -172,7 +197,7 @@ class TelegramService:
             "photo_url": photo_url,
             "requires_ack": require_ack,
         }
-        data = self._load_log()
+        data = self._load_log_all()
         data.append(log_entry)
         self._save_log(data)
         return result.message_id


### PR DESCRIPTION
## Summary
- extend `SentMessage` model with optional broadcast info
- log broadcast events and support deleting logged messages
- provide API endpoint to remove message history items
- add multi-select for sending messages to multiple employees
- display recent message history on the payouts page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687437bcc510832981edc04d1a5a0af3