### PR TITLE
Add sales analytics filter UI

### DIFF
--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -3,12 +3,33 @@ import api from '../api';
 
 export default function Analytics() {
   const [data, setData] = useState(null);
+  const [details, setDetails] = useState(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [periodInput, setPeriodInput] = useState('');
+  const [employee, setEmployee] = useState('');
 
   async function load(refresh = false) {
     try {
       const url = refresh ? 'analytics/sales/refresh' : 'analytics/sales';
       const res = await api.get(url);
       setData(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function loadDetails() {
+    try {
+      const params = new URLSearchParams();
+      if (periodInput) {
+        const [y, m, d] = periodInput.split('-');
+        params.append('period', `${d}.${m}.${y}`);
+      }
+      if (employee) params.append('employee', employee);
+      const query = params.toString() ? `?${params.toString()}` : '';
+      const res = await api.get(`analytics/sales/details${query}`);
+      setDetails(res.data);
+      setShowDetails(true);
     } catch (err) {
       console.error(err);
     }
@@ -23,6 +44,7 @@ export default function Analytics() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Аналитика продаж</h1>
       <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={() => load(true)}>Обновить</button>
+      <button className="bg-indigo-600 text-white px-3 py-2 rounded ml-2" onClick={loadDetails}>Аналитика продаж</button>
       {data && (
         <div className="grid grid-cols-2 gap-4 bg-white p-4 rounded shadow">
           <div>
@@ -43,6 +65,54 @@ export default function Analytics() {
           </div>
           <div className="col-span-2 text-sm text-gray-500">
             Обновлено: {new Date(data.updated_at).toLocaleString('ru-RU')}
+          </div>
+        </div>
+      )}
+      {showDetails && details && (
+        <div className="space-y-2 bg-white p-4 rounded shadow">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="date"
+              className="border p-2"
+              value={periodInput}
+              onChange={(e) => setPeriodInput(e.target.value)}
+            />
+            <input
+              className="border p-2 flex-grow"
+              placeholder="Сотрудник"
+              value={employee}
+              onChange={(e) => setEmployee(e.target.value)}
+            />
+            <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={loadDetails}>
+              Фильтр
+            </button>
+          </div>
+          <div className="text-sm text-gray-600">
+            Всего записей: {details.count} | Средняя стоимость: {details.avg.toFixed(2)} ₽
+          </div>
+          <div className="overflow-auto max-h-96">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="p-2 text-left">Период</th>
+                  <th className="p-2 text-left">Номер заказа</th>
+                  <th className="p-2 text-left">Сотрудник</th>
+                  <th className="p-2 text-left">Наименование</th>
+                  <th className="p-2 text-left">Стоимость</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {details.items.map((it, idx) => (
+                  <tr key={idx}>
+                    <td className="p-2">{it.period}</td>
+                    <td className="p-2">{it.order_number}</td>
+                    <td className="p-2">{it.employee}</td>
+                    <td className="p-2">{it.item}</td>
+                    <td className="p-2">{it.cost}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/app/api/analytics.py
+++ b/app/api/analytics.py
@@ -14,4 +14,8 @@ def create_analytics_router(service: AnalyticsService) -> APIRouter:
     async def refresh_sales():
         return await service.refresh_sales()
 
+    @router.get("/sales/details")
+    async def get_sales_details(period: str | None = None, employee: str | None = None):
+        return await service.get_sales_details(period, employee)
+
     return router

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,7 @@ settings = _load_settings()
 
 TOKEN = settings.telegram_bot_token
 EXCEL_FILE = settings.excel_file
+SALES_FILE = settings.sales_file
 USERS_FILE = settings.users_file
 ADVANCE_REQUESTS_FILE = settings.advance_requests_file
 VACATIONS_FILE = settings.vacations_file

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import pandas as pd
 
-from ..config import EXCEL_FILE
+from ..config import EXCEL_FILE, SALES_FILE
 from ..core.constants import MONTHS_RU
 from ..utils.logger import log
 
@@ -71,3 +71,38 @@ class AnalyticsService:
 
     async def refresh_sales(self) -> dict:
         return self._collect_sales()
+
+    def _load_sales_details(self) -> pd.DataFrame | None:
+        try:
+            df = pd.read_excel(
+                SALES_FILE,
+                header=None,
+                usecols="A,B,E,G,I",
+                names=["period", "order_number", "employee", "item", "cost"],
+            )
+            df["cost"] = pd.to_numeric(df["cost"], errors="coerce").fillna(0)
+            df.dropna(how="all", inplace=True)
+            return df
+        except Exception as exc:
+            log(f"❌ Failed to read sales details: {exc}")
+            return None
+
+    async def get_sales_details(
+        self, period: str | None = None, employee: str | None = None
+    ) -> dict:
+        df = self._load_sales_details()
+        if df is None:
+            return {"items": [], "total": 0, "count": 0, "avg": 0}
+        if period:
+            df = df[df["period"].astype(str) == str(period)]
+        if employee:
+            df = df[df["employee"].str.contains(str(employee), case=False, na=False)]
+        total = int(df["cost"].sum())
+        count = int(len(df))
+        avg = float(total / count) if count else 0.0
+        return {
+            "items": df.to_dict(orient="records"),
+            "total": total,
+            "count": count,
+            "avg": avg,
+        }

--- a/app/settings.py
+++ b/app/settings.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
 
     telegram_bot_token: str = Field("dummy", env="TELEGRAM_BOT_TOKEN")
     excel_file: str = Field("data.xlsx", env="EXCEL_FILE")
+    sales_file: str = Field("telegram_bot/Парсинг/товары.xlsx", env="SALES_FILE")
     users_file: str = Field("user.json", env="USERS_FILE")
     advance_requests_file: str = Field(
         "advance_requests.json", env="ADVANCE_REQUESTS_FILE"


### PR DESCRIPTION
## Summary
- add period and employee filters for sales details
- update API to accept period and employee query params
- filter sales dataframe by employee on the backend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687526d339a08329854fbb817c98816f