### PR TITLE
Add async sales analytics with pagination

### DIFF
--- a/app/api/analytics.py
+++ b/app/api/analytics.py
@@ -15,7 +15,32 @@ def create_analytics_router(service: AnalyticsService) -> APIRouter:
         return await service.refresh_sales()
 
     @router.get("/sales/details")
-    async def get_sales_details(period: str | None = None):
-        return await service.get_sales_details(period)
+    async def get_sales_details(
+        period: str | None = None,
+        period_from: str | None = None,
+        period_to: str | None = None,
+        employee: str | None = None,
+        item: str | None = None,
+        min_cost: float | None = None,
+        max_cost: float | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ):
+        return await service.get_sales_details(
+            period=period,
+            period_from=period_from,
+            period_to=period_to,
+            employee=employee,
+            item=item,
+            min_cost=min_cost,
+            max_cost=max_cost,
+            page=page,
+            page_size=page_size,
+        )
+
+    @router.post("/sales/details/refresh")
+    async def refresh_sales_details():
+        await service.refresh_sales_details()
+        return {"status": "ok"}
 
     return router

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
+import asyncio
+import os
 
 import pandas as pd
 
@@ -16,6 +19,8 @@ class AnalyticsService:
     def __init__(self) -> None:
         self._data: Optional[dict] = None
         self._updated_at: Optional[datetime] = None
+        self._details_df: Optional[pd.DataFrame] = None
+        self._details_mtime: float = 0.0
 
     def _collect_sales(self) -> dict:
         try:
@@ -72,33 +77,140 @@ class AnalyticsService:
     async def refresh_sales(self) -> dict:
         return self._collect_sales()
 
-    def _load_sales_details(self) -> pd.DataFrame | None:
-        try:
-            df = pd.read_excel(
+    async def refresh_sales_details(self) -> None:
+        """Force refresh cached sales details."""
+        await self._ensure_details_df(force=True)
+
+    async def _read_sales_file(self) -> pd.DataFrame:
+        def _read() -> pd.DataFrame:
+            return pd.read_excel(
                 SALES_FILE,
                 header=None,
                 usecols="A,B,E,G,I",
                 names=["period", "order_number", "employee", "item", "cost"],
             )
-            df["cost"] = pd.to_numeric(df["cost"], errors="coerce").fillna(0)
-            df.dropna(how="all", inplace=True)
-            return df
+
+        return await asyncio.to_thread(_read)
+
+    async def _ensure_details_df(self, force: bool = False) -> pd.DataFrame | None:
+        try:
+            mtime = os.path.getmtime(SALES_FILE)
+        except Exception as exc:
+            log(f"❌ Failed to stat sales file: {exc}")
+            return None
+
+        if self._details_df is not None and not force and mtime == self._details_mtime:
+            return self._details_df
+
+        start = datetime.utcnow()
+        try:
+            df = await self._read_sales_file()
         except Exception as exc:
             log(f"❌ Failed to read sales details: {exc}")
             return None
 
-    async def get_sales_details(self, period: str | None = None) -> dict:
-        df = self._load_sales_details()
+        df.columns = ["period", "order_number", "employee", "item", "cost"]
+        df.dropna(how="all", inplace=True)
+        df["cost"] = pd.to_numeric(df["cost"], errors="coerce").fillna(0)
+        df["order_number"] = df["order_number"].astype(str).str.strip()
+        df = df[
+            df["order_number"].notna()
+            & (df["order_number"] != "")
+            & (df["order_number"].str.lower() != "nan")
+        ]
+        df["period"] = pd.to_datetime(df["period"], errors="coerce", dayfirst=True)
+        dropped = df["period"].isna().sum()
+        if dropped:
+            log(f"⚠️ Dropped {dropped} rows with invalid period")
+        df = df.dropna(subset=["period"]).reset_index(drop=True)
+
+        self._details_df = df
+        self._details_mtime = mtime
+        elapsed = (datetime.utcnow() - start).total_seconds()
+        log(f"✅ Loaded {len(df)} sales details in {elapsed:.2f}s")
+        return df
+
+    async def get_sales_details(
+        self,
+        period: str | None = None,
+        period_from: str | None = None,
+        period_to: str | None = None,
+        employee: str | None = None,
+        item: str | None = None,
+        min_cost: float | None = None,
+        max_cost: float | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict:
+        df = await self._ensure_details_df()
         if df is None:
-            return {"items": [], "total": 0, "count": 0, "avg": 0}
+            return {
+                "items": [],
+                "total": 0,
+                "count": 0,
+                "avg": 0,
+                "page": page,
+                "pages": 0,
+            }
+
+        filtered = df
         if period:
-            df = df[df["period"].astype(str) == str(period)]
-        total = int(df["cost"].sum())
-        count = int(len(df))
-        avg = float(total / count) if count else 0.0
+            dt = pd.to_datetime(period, errors="coerce", dayfirst=True)
+            if not pd.isna(dt):
+                filtered = filtered[filtered["period"] == dt]
+            else:
+                filtered = filtered.iloc[0:0]
+
+        if period_from:
+            dt_from = pd.to_datetime(period_from, errors="coerce", dayfirst=True)
+            if not pd.isna(dt_from):
+                filtered = filtered[filtered["period"] >= dt_from]
+
+        if period_to:
+            dt_to = pd.to_datetime(period_to, errors="coerce", dayfirst=True)
+            if not pd.isna(dt_to):
+                filtered = filtered[filtered["period"] <= dt_to]
+
+        if employee:
+            filtered = filtered[
+                filtered["employee"].astype(str).str.contains(employee, case=False, na=False)
+            ]
+
+        if item:
+            filtered = filtered[
+                filtered["item"].astype(str).str.contains(item, case=False, na=False)
+            ]
+
+        if min_cost is not None:
+            filtered = filtered[filtered["cost"] >= float(min_cost)]
+
+        if max_cost is not None:
+            filtered = filtered[filtered["cost"] <= float(max_cost)]
+
+        page_size = max(1, min(50, int(page_size)))
+        page = max(1, int(page))
+        total_count = int(len(filtered))
+        total_pages = int((total_count + page_size - 1) / page_size)
+        start = (page - 1) * page_size
+        end = start + page_size
+        page_df = filtered.iloc[start:end].copy()
+
+        # format period back to string
+        page_df["period"] = page_df["period"].dt.strftime("%Y-%m-%d")
+
+        total_cost = int(filtered["cost"].sum())
+        avg = float(total_cost / total_count) if total_count else 0.0
+
+        log(
+            f"🔎 Filtered {total_count} records (page {page}/{total_pages})"
+        )
+
         return {
-            "items": df.to_dict(orient="records"),
-            "total": total,
-            "count": count,
+            "items": page_df.to_dict(orient="records"),
+            "total": total_cost,
+            "count": total_count,
             "avg": avg,
+            "page": page,
+            "pages": total_pages,
         }
+

--- a/tests/test_payment_request_pattern.py
+++ b/tests/test_payment_request_pattern.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 import types
 import pytest
+import asyncio
 from app.handlers.user import payout
 from app.services import advance_requests
 
@@ -70,13 +71,13 @@ def test_payment_request_pattern_ignore_case():
     assert PAYMENT_REQUEST_PATTERN.match(text)
 
 
-@pytest.mark.asyncio
-async def test_payment_request_pattern_triggers_start():
-    bot = Bot("TEST", request=AsyncMock())
-    context = types.SimpleNamespace(
-        application=types.SimpleNamespace(chat_data={}), user_data={}
-    )
-    with (
+def test_payment_request_pattern_triggers_start():
+    async def _run():
+        bot = Bot("TEST", request=AsyncMock())
+        context = types.SimpleNamespace(
+            application=types.SimpleNamespace(chat_data={}), user_data={}
+        )
+        with (
         patch("telegram.Message.reply_text", new=AsyncMock()) as reply,
         patch("app.handlers.user.payout.load_users_map", return_value={"1": {
             "name": "Test",
@@ -86,42 +87,64 @@ async def test_payment_request_pattern_triggers_start():
         }}),
         patch("app.handlers.user.payout.check_pending_request", return_value=False),
     ):
-        update = _make_message(bot, "💰 Запросить выплату")
-        state = await payout.request_payout_start(update, context)
-    assert state == PayoutStates.SELECT_TYPE
-    assert context.user_data["payout_in_progress"] is True
-    assert reply.called
-
-
-@pytest.mark.asyncio
-async def test_full_payout_conversation_creates_record():
-    bot = Bot("TEST", request=AsyncMock())
-    repo = DummyRepo()
-    advance_requests._repo = repo
-    context = types.SimpleNamespace(
-        application=types.SimpleNamespace(chat_data={}), user_data={}
-    )
-    with (
-        patch("telegram.Message.reply_text", new=AsyncMock()),
-        patch("telegram.Bot.edit_message_text", new=AsyncMock()),
-        patch("app.handlers.user.payout.TelegramService.send_payout_request_to_admin", new=AsyncMock()),
-        patch("app.handlers.user.payout.load_users_map", return_value={"1": {
-            "name": "Test",
-            "phone": "123",
-            "bank": "TB",
-            "card_number": "9999",
-        }}),
-        patch("app.handlers.user.payout.check_pending_request", return_value=False),
-        patch("app.handlers.user.payout.load_advance_requests", return_value=[]),
-    ):
-        state = await payout.request_payout_start(_make_message(bot, "💰 Запросить выплату"), context)
+            update = _make_message(bot, "💰 Запросить выплату")
+            state = await payout.request_payout_start(update, context)
         assert state == PayoutStates.SELECT_TYPE
-        state = await payout.select_type(_make_message(bot, "Аванс", update_id=2), context)
-        assert state == PayoutStates.ENTER_AMOUNT
-        state = await payout.enter_amount(_make_message(bot, "1000", update_id=3), context)
-        assert state == PayoutStates.SELECT_METHOD
-        state = await payout.select_method(_make_message(bot, "💳 На карту", update_id=4), context)
-        assert state == PayoutStates.CONFIRM_CARD
-        state = await payout.confirm_card(_make_callback(bot, "payout_confirm", update_id=5), context)
-        assert state == ConversationHandler.END
-    assert len(repo.records) == 1
+        assert context.user_data["payout_in_progress"] is True
+        assert reply.called
+
+    asyncio.run(_run())
+
+
+def test_full_payout_conversation_creates_record():
+    async def _run():
+        bot = Bot("TEST", request=AsyncMock())
+        repo = DummyRepo()
+        advance_requests._repo = repo
+        context = types.SimpleNamespace(
+            application=types.SimpleNamespace(chat_data={}), user_data={}
+        )
+        with (
+            patch("telegram.Message.reply_text", new=AsyncMock()),
+            patch("telegram.Bot.edit_message_text", new=AsyncMock()),
+            patch(
+                "app.handlers.user.payout.TelegramService.send_payout_request_to_admin",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.handlers.user.payout.load_users_map",
+                return_value={
+                    "1": {
+                        "name": "Test",
+                        "phone": "123",
+                        "bank": "TB",
+                        "card_number": "9999",
+                    }
+                },
+            ),
+            patch("app.handlers.user.payout.check_pending_request", return_value=False),
+            patch("app.handlers.user.payout.load_advance_requests", return_value=[]),
+        ):
+            state = await payout.request_payout_start(
+                _make_message(bot, "💰 Запросить выплату"), context
+            )
+            assert state == PayoutStates.SELECT_TYPE
+            state = await payout.select_type(
+                _make_message(bot, "Аванс", update_id=2), context
+            )
+            assert state == PayoutStates.ENTER_AMOUNT
+            state = await payout.enter_amount(
+                _make_message(bot, "1000", update_id=3), context
+            )
+            assert state == PayoutStates.SELECT_METHOD
+            state = await payout.select_method(
+                _make_message(bot, "💳 На карту", update_id=4), context
+            )
+            assert state == PayoutStates.CONFIRM_CARD
+            state = await payout.confirm_card(
+                _make_callback(bot, "payout_confirm", update_id=5), context
+            )
+            assert state == ConversationHandler.END
+        assert len(repo.records) == 1
+
+    asyncio.run(_run())

--- a/tests/test_sales_analytics.py
+++ b/tests/test_sales_analytics.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import asyncio
+from pathlib import Path
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.services.analytics import AnalyticsService
+from app import config
+
+
+def create_sales_file(path: Path):
+    # Create dataframe with at least 9 columns to match usecols "A,B,E,G,I"
+    rows = [
+        ["2024-01", "001", None, None, "Alice", None, "Shampoo", None, 100],
+        ["2024-02", "002", None, None, "Bob", None, "Conditioner", None, "200"],
+        ["bad", "003", None, None, "Charlie", None, "Mask", None, 300],
+        ["2024-03", "", None, None, "Dave", None, "Gel", None, 400],
+        [None, None, None, None, None, None, None, None, None],
+    ]
+    df = pd.DataFrame(rows)
+    df.to_excel(path, index=False, header=False)
+
+
+def test_load_and_filter_sales(tmp_path, monkeypatch):
+    file = tmp_path / "sales.xlsx"
+    create_sales_file(file)
+    monkeypatch.setattr(config, "SALES_FILE", str(file))
+    from app.services import analytics
+    monkeypatch.setattr(analytics, "SALES_FILE", str(file))
+    svc = AnalyticsService()
+    result = asyncio.run(svc.get_sales_details())
+    assert result["count"] == 2
+    assert len(result["items"]) == 2
+    assert result["items"][0]["employee"] == "Alice"
+    assert result["items"][1]["cost"] == 200
+
+    result = asyncio.run(svc.get_sales_details(employee="bob"))
+    assert result["count"] == 1
+    assert result["items"][0]["employee"] == "Bob"
+
+    result = asyncio.run(svc.get_sales_details(page=2, page_size=1))
+    assert result["page"] == 2
+    assert result["pages"] == 2
+    assert len(result["items"]) == 1


### PR DESCRIPTION
## Summary
- implement asynchronous loading of sales details
- add filtering and pagination options
- cache sales details
- expose new query params in analytics API
- adjust existing tests and add new tests for analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754daf2b88832987c775f030956632