### PR TITLE
Update sales analytics details filters

### DIFF
--- a/admin_frontend/package.json
+++ b/admin_frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.10.0",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",

--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -5,7 +5,13 @@ export default function Analytics() {
   const [data, setData] = useState(null);
   const [details, setDetails] = useState(null);
   const [showDetails, setShowDetails] = useState(false);
-  const [period, setPeriod] = useState('');
+  const [filters, setFilters] = useState({
+    from: '',
+    to: '',
+    code: '',
+    name: '',
+    doc: '',
+  });
 
   async function load(refresh = false) {
     try {
@@ -19,8 +25,14 @@ export default function Analytics() {
 
   async function loadDetails() {
     try {
-      const query = period ? `?period=${encodeURIComponent(period)}` : '';
-      const res = await api.get(`analytics/sales/details${query}`);
+      const params = {
+        date_from: filters.from || undefined,
+        date_to: filters.to || undefined,
+        code_substr: filters.code || undefined,
+        name_substr: filters.name || undefined,
+        doc_num_substr: filters.doc || undefined,
+      };
+      const res = await api.get('analytics/sales/details', { params });
       setDetails(res.data);
       setShowDetails(true);
     } catch (err) {
@@ -63,12 +75,36 @@ export default function Analytics() {
       )}
       {showDetails && details && (
         <div className="space-y-2 bg-white p-4 rounded shadow">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="date"
+              className="border p-2"
+              value={filters.from}
+              onChange={(e) => setFilters({ ...filters, from: e.target.value })}
+            />
+            <input
+              type="date"
+              className="border p-2"
+              value={filters.to}
+              onChange={(e) => setFilters({ ...filters, to: e.target.value })}
+            />
+            <input
+              className="border p-2"
+              placeholder="Код"
+              value={filters.code}
+              onChange={(e) => setFilters({ ...filters, code: e.target.value })}
+            />
             <input
               className="border p-2 flex-grow"
-              placeholder="Период"
-              value={period}
-              onChange={(e) => setPeriod(e.target.value)}
+              placeholder="Название"
+              value={filters.name}
+              onChange={(e) => setFilters({ ...filters, name: e.target.value })}
+            />
+            <input
+              className="border p-2"
+              placeholder="№ заказа"
+              value={filters.doc}
+              onChange={(e) => setFilters({ ...filters, doc: e.target.value })}
             />
             <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={loadDetails}>
               Фильтр
@@ -81,23 +117,38 @@ export default function Analytics() {
             <table className="min-w-full text-sm">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="p-2 text-left">Период</th>
-                  <th className="p-2 text-left">Номер заказа</th>
-                  <th className="p-2 text-left">Сотрудник</th>
+                  <th className="p-2 text-left">Дата</th>
+                  <th className="p-2 text-left">№ док.</th>
+                  <th className="p-2 text-left">Creator</th>
+                  <th className="p-2 text-left">Описание</th>
+                  <th className="p-2 text-left">Код товара</th>
                   <th className="p-2 text-left">Наименование</th>
-                  <th className="p-2 text-left">Стоимость</th>
+                  <th className="p-2 text-left">Сумма</th>
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {details.items.map((it, idx) => (
-                  <tr key={idx}>
-                    <td className="p-2">{it.period}</td>
-                    <td className="p-2">{it.order_number}</td>
-                    <td className="p-2">{it.employee}</td>
-                    <td className="p-2">{it.item}</td>
-                    <td className="p-2">{it.cost}</td>
-                  </tr>
-                ))}
+                {details.items.map((raw, idx) => {
+                  const it = {
+                    doc_date: raw.doc_date || raw.period,
+                    doc_num: raw.doc_num || raw.doc_number || raw.order_number,
+                    creator_id: raw.creator_id || raw.employee,
+                    description: raw.description || raw.item,
+                    item_code: raw.item_code || '',
+                    item_name: raw.item_name || raw.item,
+                    kredit: raw.kredit ?? raw.cost,
+                  };
+                  return (
+                    <tr key={idx}>
+                      <td className="p-2">{it.doc_date}</td>
+                      <td className="p-2">{it.doc_num}</td>
+                      <td className="p-2">{it.creator_id}</td>
+                      <td className="p-2">{it.description}</td>
+                      <td className="p-2">{it.item_code}</td>
+                      <td className="p-2">{it.item_name}</td>
+                      <td className="p-2">{it.kredit}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- use individual filter fields in Analytics page
- query analytics details with date range and other filters
- display Firebird query fields in details table
- add missing dependency for admin frontend

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68764fbc79748329b656f0ad1bd9db4f