### PR TITLE
Fix refresh call for sales analytics

### DIFF
--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -59,8 +59,9 @@ export default function Analytics() {
 
   async function load(refresh = false) {
     try {
-      const url = refresh ? 'analytics/sales/refresh' : 'analytics/sales';
-      const res = await api.get(url);
+      const res = refresh
+        ? await api.post('analytics/sales/refresh')
+        : await api.get('analytics/sales');
       setData(res.data);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- call POST /analytics/sales/refresh in React admin panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876726e8d04832986178b22d943812f