### PR TITLE
Add sales rating and sorting

### DIFF
--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -37,6 +37,9 @@ export default function Analytics() {
   const [data, setData] = useState(null);
   const [details, setDetails] = useState(null);
   const [showDetails, setShowDetails] = useState(false);
+  const [rating, setRating] = useState([]);
+  const [ratingRange, setRatingRange] = useState({ from: '', to: '' });
+  const [sort, setSort] = useState('');
   const [filters, setFilters] = useState({
     from: '',
     to: '',
@@ -86,6 +89,19 @@ export default function Analytics() {
     }
   }
 
+  async function loadRating() {
+    try {
+      const params = {
+        date_from: ratingRange.from || undefined,
+        date_to: ratingRange.to || undefined,
+      };
+      const res = await api.get('analytics/sales/rating', { params });
+      setRating(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   useEffect(() => {
     load();
     window.refreshPage = load;
@@ -111,6 +127,13 @@ export default function Analytics() {
   const filteredDetails = filters.employee
     ? mappedDetails.filter((item) => item.employee === filters.employee)
     : mappedDetails;
+
+  const sortedDetails = [...filteredDetails];
+  if (sort === 'employee') {
+    sortedDetails.sort((a, b) => a.employee.localeCompare(b.employee));
+  } else if (sort === 'cost') {
+    sortedDetails.sort((a, b) => Number(b.cost) - Number(a.cost));
+  }
 
   // Итоги
   const goodsCount = filteredDetails.filter((item) => Number(item.cost) > 0).length;
@@ -204,6 +227,15 @@ export default function Analytics() {
               value={filters.doc}
               onChange={(e) => setFilters({ ...filters, doc: e.target.value })}
             />
+            <select
+              className="border p-2"
+              value={sort}
+              onChange={(e) => setSort(e.target.value)}
+            >
+              <option value="">Без сортировки</option>
+              <option value="employee">По сотруднику</option>
+              <option value="cost">По сумме</option>
+            </select>
             <button
               className="bg-blue-600 text-white px-3 py-2 rounded"
               onClick={loadDetails}
@@ -229,7 +261,7 @@ export default function Analytics() {
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {filteredDetails.map((it, idx) => (
+                {sortedDetails.map((it, idx) => (
                   <tr key={idx}>
                     <td className="p-2">{formatDateRu(it.date)}</td>
                     <td className="p-2">{it.number}</td>
@@ -241,6 +273,53 @@ export default function Analytics() {
                 ))}
               </tbody>
             </table>
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <h3 className="font-semibold">Рейтинг сотрудников</h3>
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="date"
+                className="border p-2"
+                value={ratingRange.from}
+                onChange={(e) =>
+                  setRatingRange({ ...ratingRange, from: e.target.value })
+                }
+              />
+              <input
+                type="date"
+                className="border p-2"
+                value={ratingRange.to}
+                onChange={(e) =>
+                  setRatingRange({ ...ratingRange, to: e.target.value })
+                }
+              />
+              <button
+                className="bg-blue-600 text-white px-3 py-2 rounded"
+                onClick={loadRating}
+              >
+                Показать
+              </button>
+            </div>
+
+            <div className="overflow-auto max-h-60">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="p-2 text-left">Сотрудник</th>
+                    <th className="p-2 text-left">Сумма</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {rating.map((r, idx) => (
+                    <tr key={idx}>
+                      <td className="p-2">{mapEmployee(r.description || r.employee)}</td>
+                      <td className="p-2">{r.total}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       )}

--- a/app/api/analytics.py
+++ b/app/api/analytics.py
@@ -49,4 +49,20 @@ def create_analytics_router(service: AnalyticsService) -> APIRouter:
         await service.refresh_sales_details()
         return {"status": "ok"}
 
+    @router.get("/sales/rating")
+    async def get_sales_rating(
+        date_from: str | None = None,
+        date_to: str | None = None,
+        creater_ids: str | None = None,
+        user_ids: str | None = None,
+        folder_ids: str | None = None,
+    ):
+        return await service.get_sales_rating(
+            date_from=date_from,
+            date_to=date_to,
+            creater_ids=creater_ids.split(",") if creater_ids else None,
+            user_ids=user_ids.split(",") if user_ids else None,
+            folder_ids=folder_ids.split(",") if folder_ids else None,
+        )
+
     return router

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -403,3 +403,110 @@ class AnalyticsService:
             "page": page,
             "pages": total_pages,
         }
+
+    async def _firebird_rating(
+        self,
+        date_from: str | None,
+        date_to: str | None,
+        creater_ids: list[str] | None,
+        user_ids: list[str] | None,
+        folder_ids: list[str],
+    ) -> list[dict] | None:
+        """Return aggregated sales by employee from Firebird."""
+        if not self._fb:
+            return None
+
+        filters = ["docs_order_history.status_id = 5"]
+        params: list[Any] = []
+        if date_from:
+            filters.append("docs.doc_date >= ?")
+            params.append(date_from)
+        if date_to:
+            filters.append("docs.doc_date <= ?")
+            params.append(date_to)
+        if creater_ids:
+            placeholders = ",".join(["?"] * len(creater_ids))
+            filters.append(f"docs_order.creater_id IN ({placeholders})")
+            params.extend(creater_ids)
+        if user_ids:
+            placeholders = ",".join(["?"] * len(user_ids))
+            filters.append(f"users.user_id IN ({placeholders})")
+            params.extend(user_ids)
+        if folder_ids:
+            placeholders = ",".join(["?"] * len(folder_ids))
+            filters.append(f"tovars_tbl.folder_id IN ({placeholders})")
+            params.extend(folder_ids)
+
+        where_clause = " AND ".join(filters)
+        if where_clause:
+            where_clause = "WHERE " + where_clause
+
+        base_from = (
+            "FROM doc_order_lines "
+            "INNER JOIN docs_order ON doc_order_lines.doc_order_id = docs_order.id "
+            "INNER JOIN docs_order_history ON docs_order.id = docs_order_history.doc_order_id "
+            "INNER JOIN docs ON docs_order.doc_id = docs.doc_id "
+            "INNER JOIN contragents ON docs.contragent_id = contragents.contr_id "
+            "INNER JOIN tovars_tbl ON doc_order_lines.tovar_id = tovars_tbl.tovar_id "
+            "INNER JOIN users ON docs_order.creater_id = users.user_id "
+        )
+
+        query = (
+            "SELECT users.description AS description, "
+            "SUM(doc_order_lines.kredit) AS total "
+            f"{base_from} {where_clause} GROUP BY users.description ORDER BY total DESC"
+        )
+
+        try:
+            rows = await self._fb.cached_execute(tuple(params), query, params)
+        except Exception as exc:
+            log(f"❌ Firebird rating query failed: {exc}")
+            return None
+
+        for row in rows:
+            row["description"] = map_employee_by_code(row.get("description"))
+            row["total"] = int(row.get("total") or 0)
+
+        return rows
+
+    async def get_sales_rating(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        creater_ids: list[str] | None = None,
+        user_ids: list[str] | None = None,
+        folder_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Return rating of employees by sales amount."""
+        if self._fb:
+            return await self._firebird_rating(
+                date_from,
+                date_to,
+                creater_ids or [],
+                user_ids or [],
+                folder_ids or [],
+            ) or []
+
+        df = await self._ensure_details_df()
+        if df is None:
+            return []
+
+        filtered = df
+        if date_from:
+            dt_from = pd.to_datetime(date_from, errors="coerce", dayfirst=True)
+            if not pd.isna(dt_from):
+                filtered = filtered[filtered["period"] >= dt_from]
+
+        if date_to:
+            dt_to = pd.to_datetime(date_to, errors="coerce", dayfirst=True)
+            if not pd.isna(dt_to):
+                filtered = filtered[filtered["period"] <= dt_to]
+
+        grouped = (
+            filtered.groupby("employee")["cost"].sum().reset_index().rename(columns={"cost": "total"})
+        )
+
+        grouped["total"] = grouped["total"].astype(int)
+        grouped = grouped.sort_values("total", ascending=False)
+
+        return grouped.to_dict(orient="records")

--- a/tests/test_sales_analytics.py
+++ b/tests/test_sales_analytics.py
@@ -44,3 +44,22 @@ def test_load_and_filter_sales(tmp_path, monkeypatch):
     assert result["page"] == 2
     assert result["pages"] == 2
     assert len(result["items"]) == 1
+
+
+def test_sales_rating(tmp_path, monkeypatch):
+    file = tmp_path / "sales.xlsx"
+    create_sales_file(file)
+    monkeypatch.setattr(config, "SALES_FILE", str(file))
+    from app.services import analytics
+    monkeypatch.setattr(analytics, "SALES_FILE", str(file))
+    svc = AnalyticsService()
+
+    rating = asyncio.run(svc.get_sales_rating())
+    assert rating[0]["employee"] == "Bob"
+    assert rating[0]["total"] == 200
+    assert rating[1]["employee"] == "Alice"
+    assert rating[1]["total"] == 100
+
+    rating = asyncio.run(svc.get_sales_rating(date_to="2024-01-31"))
+    assert len(rating) == 1
+    assert rating[0]["employee"] == "Alice"


### PR DESCRIPTION
## Summary
- implement sales rating API and service logic
- add sorting and rating UI to analytics page
- test sales rating calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767da28a04832987f7a4ba218fcb72