### PR TITLE
Fix details fetch button event

### DIFF
--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -155,7 +155,7 @@ export default function Analytics() {
       </button>
       <button
         className="bg-indigo-600 text-white px-3 py-2 rounded ml-2"
-        onClick={loadDetails}
+        onClick={() => loadDetails()}
       >
         Аналитика продаж
       </button>
@@ -255,7 +255,7 @@ export default function Analytics() {
             </select>
             <button
               className="bg-blue-600 text-white px-3 py-2 rounded"
-              onClick={loadDetails}
+              onClick={() => loadDetails()}
             >
               Фильтр
             </button>


### PR DESCRIPTION
## Summary
- ensure sales details button doesn't send event object as page_size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877af80f3308329a8ead54af1e3ecd6