### PR TITLE
Add dictionary fields for all dropdowns

### DIFF
--- a/admin_frontend/src/pages/Dictionary.jsx
+++ b/admin_frontend/src/pages/Dictionary.jsx
@@ -2,6 +2,21 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import api from '../api';
 
+const FIELDS = {
+  positions: 'Должности',
+  employee_statuses: 'Статусы сотрудников',
+  payout_types: 'Типы выплат',
+  payout_methods: 'Способы выплат',
+  payout_statuses: 'Статусы выплат',
+  payout_control_types: 'Типы заявок на выплаты',
+  payout_control_methods: 'Способы заявок на выплаты',
+  vacation_types: 'Типы отпусков',
+  incentive_types: 'Типы штрафов и премий',
+  broadcast_statuses: 'Статусы рассылки',
+  analytics_leader_options: 'Поля лидеров аналитики',
+  analytics_sort_options: 'Поля сортировки аналитики',
+};
+
 export default function Dictionary() {
   const { register, handleSubmit, reset } = useForm({ defaultValues: {} });
   const [loaded, setLoaded] = useState(false);
@@ -13,7 +28,11 @@ export default function Dictionary() {
   async function load() {
     try {
       const res = await api.get('dictionary/');
-      reset({ positions: (res.data.positions || []).join(', ') });
+      const defaults = {};
+      Object.keys(FIELDS).forEach((key) => {
+        defaults[key] = (res.data[key] || []).join(', ');
+      });
+      reset(defaults);
       setLoaded(true);
     } catch (err) {
       console.error(err);
@@ -21,12 +40,13 @@ export default function Dictionary() {
   }
 
   async function save(values) {
-    const payload = {
-      positions: values.positions
+    const payload = {};
+    Object.keys(FIELDS).forEach((key) => {
+      payload[key] = values[key]
         .split(',')
         .map((s) => s.trim())
-        .filter(Boolean),
-    };
+        .filter(Boolean);
+    });
     try {
       await api.patch('dictionary/', payload);
       alert('Сохранено');
@@ -44,14 +64,16 @@ export default function Dictionary() {
     <div className="space-y-6 max-w-3xl mx-auto">
       <h2 className="text-2xl font-semibold">Словарь</h2>
       <form onSubmit={handleSubmit(save)} className="space-y-4">
-        <section className="border rounded p-3 space-y-2">
-          <h3 className="font-semibold">Должности</h3>
-          <textarea
-            className="border p-2 w-full"
-            placeholder="Должности, через запятую"
-            {...register('positions')}
-          />
-        </section>
+        {Object.entries(FIELDS).map(([key, label]) => (
+          <section key={key} className="border rounded p-3 space-y-2">
+            <h3 className="font-semibold">{label}</h3>
+            <textarea
+              className="border p-2 w-full"
+              placeholder={`${label}, через запятую`}
+              {...register(key)}
+            />
+          </section>
+        ))}
         <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">
           Сохранить
         </button>

--- a/dictionary.json
+++ b/dictionary.json
@@ -17,5 +17,59 @@
     "Удалённый сотрудник",
     "Директор",
     "Технолог"
+  ],
+  "employee_statuses": [
+    "active",
+    "inactive"
+  ],
+  "payout_types": [
+    "Аванс",
+    "Зарплата"
+  ],
+  "payout_methods": [
+    "💳 На карту",
+    "🏦 Из кассы",
+    "🤝 Наличными"
+  ],
+  "payout_statuses": [
+    "Ожидает",
+    "Одобрено",
+    "Отклонено",
+    "Выплачено"
+  ],
+  "payout_control_types": [
+    "advance",
+    "final",
+    "compensation"
+  ],
+  "payout_control_methods": [
+    "card",
+    "cash",
+    "account"
+  ],
+  "vacation_types": [
+    "Отпуск",
+    "Больничный"
+  ],
+  "incentive_types": [
+    "bonus",
+    "penalty"
+  ],
+  "broadcast_statuses": [
+    "active",
+    "inactive"
+  ],
+  "analytics_leader_options": [
+    "По косметике (среднее в день)",
+    "По косметике (общая сумма)",
+    "По ремонту (среднее в день)",
+    "По ремонту (общая сумма)",
+    "По обуви (общая сумма)",
+    "По обуви (количество)",
+    "По совокупной выручке"
+  ],
+  "analytics_sort_options": [
+    "По сотруднику",
+    "По сумме"
   ]
 }


### PR DESCRIPTION
## Summary
- extend `dictionary.json` to include options from every dropdown
- generalize Dictionary page to edit all dictionary lists

## Testing
- `python -m pip install -r /tmp/req_clean.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b6a962c8329a944d6d89a52c4f5