### PR TITLE
Load dictionary defaults from constants

### DIFF
--- a/admin_frontend/src/pages/Dictionary.jsx
+++ b/admin_frontend/src/pages/Dictionary.jsx
@@ -2,6 +2,29 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import api from '../api';
 
+const FIELDS = {
+  positions: 'Должности',
+  employee_statuses: 'Статусы сотрудников',
+  payout_types: 'Типы выплат',
+  payout_methods: 'Способы выплат',
+  payout_statuses: 'Статусы выплат',
+  payout_control_types: 'Типы заявок на выплаты',
+  payout_control_methods: 'Способы заявок на выплаты',
+  vacation_types: 'Типы отпусков',
+  incentive_types: 'Типы штрафов и премий',
+  broadcast_statuses: 'Статусы рассылки',
+  analytics_leader_options: 'Поля лидеров аналитики',
+  analytics_sort_options: 'Поля сортировки аналитики',
+  asset_categories: 'Категории имущества',
+  asset_items: 'Предметы имущества',
+  asset_departments: 'Подразделения',
+  asset_sizes: 'Размеры имущества',
+  asset_statuses: 'Статусы имущества',
+  asset_issuers: 'Ответственные за выдачу',
+  uniform_items: 'Предметы формы',
+  uniform_sizes: 'Размеры формы',
+};
+
 export default function Dictionary() {
   const { register, handleSubmit, reset } = useForm({ defaultValues: {} });
   const [loaded, setLoaded] = useState(false);
@@ -13,7 +36,11 @@ export default function Dictionary() {
   async function load() {
     try {
       const res = await api.get('dictionary/');
-      reset({ positions: (res.data.positions || []).join(', ') });
+      const defaults = {};
+      Object.keys(FIELDS).forEach((key) => {
+        defaults[key] = (res.data[key] || []).join(', ');
+      });
+      reset(defaults);
       setLoaded(true);
     } catch (err) {
       console.error(err);
@@ -21,12 +48,13 @@ export default function Dictionary() {
   }
 
   async function save(values) {
-    const payload = {
-      positions: values.positions
+    const payload = {};
+    Object.keys(FIELDS).forEach((key) => {
+      payload[key] = values[key]
         .split(',')
         .map((s) => s.trim())
-        .filter(Boolean),
-    };
+        .filter(Boolean);
+    });
     try {
       await api.patch('dictionary/', payload);
       alert('Сохранено');
@@ -44,14 +72,16 @@ export default function Dictionary() {
     <div className="space-y-6 max-w-3xl mx-auto">
       <h2 className="text-2xl font-semibold">Словарь</h2>
       <form onSubmit={handleSubmit(save)} className="space-y-4">
-        <section className="border rounded p-3 space-y-2">
-          <h3 className="font-semibold">Должности</h3>
-          <textarea
-            className="border p-2 w-full"
-            placeholder="Должности, через запятую"
-            {...register('positions')}
-          />
-        </section>
+        {Object.entries(FIELDS).map(([key, label]) => (
+          <section key={key} className="border rounded p-3 space-y-2">
+            <h3 className="font-semibold">{label}</h3>
+            <textarea
+              className="border p-2 w-full"
+              placeholder={`${label}, через запятую`}
+              {...register(key)}
+            />
+          </section>
+        ))}
         <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">
           Сохранить
         </button>

--- a/app/services/dictionary_service.py
+++ b/app/services/dictionary_service.py
@@ -1,6 +1,15 @@
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from app.data.employee_repository import EmployeeRepository
+from app.data.payout_repository import PayoutRepository
+from app.data.vacation_repository import VacationRepository
+from app.data.incentive_repository import IncentiveRepository
+from app.data.asset_repository import AssetRepository
+from app.data.uniform_repository import UniformRepository
+from app.core.enums import EmployeeStatus, PAYOUT_STATUSES
+from app.core.constants import PAYOUT_METHODS, PAYOUT_TYPES
 
 
 class DictionaryService:
@@ -10,14 +19,81 @@ class DictionaryService:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
+    def _collect_defaults(self) -> Dict[str, List[str]]:
+        """Return predefined dictionary values from code constants."""
+        return {
+            "employee_statuses": [s.value for s in EmployeeStatus],
+            "payout_methods": PAYOUT_METHODS,
+            "payout_types": PAYOUT_TYPES,
+            "payout_statuses": PAYOUT_STATUSES,
+        }
+
+    def _collect_dynamic(self) -> Dict[str, List[str]]:
+        """Gather unique values from existing system records."""
+        dynamic: Dict[str, List[str]] = {}
+
+        employees = EmployeeRepository().list_employees()
+        dynamic["positions"] = [e.position for e in employees if e.position]
+        dynamic["employee_statuses"] = [e.status.value for e in employees]
+
+        payouts = PayoutRepository().load_all()
+        dynamic["payout_types"] = [
+            p.get("payout_type") for p in payouts if p.get("payout_type")
+        ]
+        dynamic["payout_methods"] = [
+            p.get("method") for p in payouts if p.get("method")
+        ]
+        dynamic["payout_statuses"] = [
+            p.get("status") for p in payouts if p.get("status")
+        ]
+
+        vacations = VacationRepository().list()
+        dynamic["vacation_types"] = [v.get("type") for v in vacations if v.get("type")]
+
+        incentives = IncentiveRepository().list()
+        dynamic["incentive_types"] = [
+            i.get("type") for i in incentives if i.get("type")
+        ]
+
+        assets = AssetRepository().list()
+        dynamic["asset_categories"] = [
+            a.get("category") for a in assets if a.get("category")
+        ]
+        dynamic["asset_items"] = [
+            a.get("item_name") for a in assets if a.get("item_name")
+        ]
+        dynamic["asset_departments"] = [
+            a.get("department") for a in assets if a.get("department")
+        ]
+        dynamic["asset_sizes"] = [a.get("size") for a in assets if a.get("size")]
+        dynamic["asset_statuses"] = [a.get("status") for a in assets if a.get("status")]
+        dynamic["asset_issuers"] = [a.get("issuer") for a in assets if a.get("issuer")]
+
+        uniforms = UniformRepository().list()
+        dynamic["uniform_items"] = [u.get("item") for u in uniforms if u.get("item")]
+        dynamic["uniform_sizes"] = [u.get("size") for u in uniforms if u.get("size")]
+
+        return dynamic
+
     def load(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
         if self.path.exists():
             try:
                 with self.path.open("r", encoding="utf-8") as f:
-                    return json.load(f)
+                    data = json.load(f)
             except Exception:
-                return {}
-        return {}
+                data = {}
+
+        dynamic = self._collect_dynamic()
+        defaults = self._collect_defaults()
+        for key in set(dynamic) | set(defaults):
+            existing = set(data.get(key, []))
+            existing.update([v for v in dynamic.get(key, []) if v])
+            existing.update([v for v in defaults.get(key, []) if v])
+            if existing:
+                data[key] = sorted(existing)
+
+        return data
 
     def save(self, data: Dict[str, Any]) -> Dict[str, Any]:
         with self.path.open("w", encoding="utf-8") as f:

--- a/dictionary.json
+++ b/dictionary.json
@@ -17,5 +17,67 @@
     "Удалённый сотрудник",
     "Директор",
     "Технолог"
-  ]
+  ],
+  "employee_statuses": [
+    "active",
+    "inactive"
+  ],
+  "payout_types": [
+    "Аванс",
+    "Зарплата"
+  ],
+  "payout_methods": [
+    "💳 На карту",
+    "🏦 Из кассы",
+    "🤝 Наличными"
+  ],
+  "payout_statuses": [
+    "Ожидает",
+    "Одобрено",
+    "Отклонено",
+    "Выплачено"
+  ],
+  "payout_control_types": [
+    "advance",
+    "final",
+    "compensation"
+  ],
+  "payout_control_methods": [
+    "card",
+    "cash",
+    "account"
+  ],
+  "vacation_types": [
+    "Отпуск",
+    "Больничный"
+  ],
+  "incentive_types": [
+    "bonus",
+    "penalty"
+  ],
+  "broadcast_statuses": [
+    "active",
+    "inactive"
+  ],
+  "analytics_leader_options": [
+    "По косметике (среднее в день)",
+    "По косметике (общая сумма)",
+    "По ремонту (среднее в день)",
+    "По ремонту (общая сумма)",
+    "По обуви (общая сумма)",
+    "По обуви (количество)",
+    "По совокупной выручке"
+  ],
+  "analytics_sort_options": [
+    "По сотруднику",
+    "По сумме"
+  ],
+  "asset_categories": [],
+  "asset_items": [],
+  "asset_departments": [],
+  "asset_sizes": [],
+  "asset_statuses": [],
+  "asset_issuers": [],
+  "uniform_items": [],
+  "uniform_sizes": []
 }

--- a/tests/test_dictionary_service.py
+++ b/tests/test_dictionary_service.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.services.dictionary_service import DictionaryService
+from app.core.enums import PAYOUT_STATUSES, EmployeeStatus
+from app.core.constants import PAYOUT_METHODS, PAYOUT_TYPES
+
+
+def test_load_includes_defaults(tmp_path):
+    path = tmp_path / "dict.json"
+    service = DictionaryService(path)
+    data = service.load()
+    assert set(data["payout_statuses"]) >= set(PAYOUT_STATUSES)
+    assert set(data["payout_methods"]) >= set(PAYOUT_METHODS)
+    assert set(data["payout_types"]) >= set(PAYOUT_TYPES)
+    assert set(data["employee_statuses"]) >= {s.value for s in EmployeeStatus}
+


### PR DESCRIPTION
## Summary
- load default dropdown values from enums and constants
- include default values in merged dictionary
- test dictionary service loading logic

## Testing
- `python -m pip install fastapi uvicorn pandas python-telegram-bot pillow pydantic pandas openpyxl`
- `python -m pip install pydantic-settings`
- `python -m pip install fdb fpdf`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d2b6a962c8329a944d6d89a52c4f5