### PR TITLE
Fix employees table width

### DIFF
--- a/admin_frontend/src/App.jsx
+++ b/admin_frontend/src/App.jsx
@@ -17,7 +17,7 @@ import Navigation from './components/Navigation.jsx';
 export default function App() {
   return (
     <Router>
-      <div className="container mx-auto p-4 space-y-6">
+      <div className="mx-auto max-w-full p-4 space-y-6">
         <Navigation />
         <Routes>
           <Route path="/admin/employees" element={<Employees />} />

--- a/admin_frontend/src/pages/Employees.jsx
+++ b/admin_frontend/src/pages/Employees.jsx
@@ -141,7 +141,7 @@ export default function Employees() {
   );
 
   return (
-    <div className="space-y-6 max-w-5xl mx-auto">
+    <div className="space-y-6 max-w-full mx-auto">
       <h2 className="text-2xl font-semibold">Сотрудники</h2>
       <UpcomingBirthdays />
       <div className="flex flex-wrap gap-2 items-center">


### PR DESCRIPTION
## Summary
- make the entire admin layout full width so employees table can show all columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e01ae3b408329857191345e80c454