### PR TITLE
Add dashboard and make employee ID editable

### DIFF
--- a/admin_frontend/src/App.jsx
+++ b/admin_frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
 import Employees from './pages/Employees';
 import Payouts from './pages/Payouts';
 import PayoutsControl from './pages/PayoutsControl';
@@ -20,6 +21,7 @@ export default function App() {
       <div className="mx-auto max-w-full p-4 space-y-6">
         <Navigation />
         <Routes>
+          <Route path="/admin" element={<Dashboard />} />
           <Route path="/admin/employees" element={<Employees />} />
           <Route path="/admin/payouts" element={<Payouts />} />
           <Route path="/admin/payouts-control" element={<PayoutsControl />} />
@@ -33,7 +35,7 @@ export default function App() {
           <Route path="/admin/assets" element={<Assets />} />
           <Route path="/admin/dictionary" element={<Dictionary />} />
           <Route path="/admin/settings" element={<Settings />} />
-          <Route path="*" element={<Navigate to="/admin/employees" replace />} />
+          <Route path="*" element={<Navigate to="/admin" replace />} />
         </Routes>
       </div>
     </Router>

--- a/admin_frontend/src/components/Navigation.jsx
+++ b/admin_frontend/src/components/Navigation.jsx
@@ -4,6 +4,10 @@ import { Menu, X } from 'lucide-react';
 
 const navStructure = [
   {
+    name: 'Обзор',
+    items: [{ to: '/admin', label: 'Дашборд' }],
+  },
+  {
     name: 'Персонал',
     items: [
       { to: '/admin/employees', label: 'Сотрудники' },

--- a/admin_frontend/src/pages/Dashboard.jsx
+++ b/admin_frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+export default function Dashboard() {
+  const [birthday, setBirthday] = useState(null);
+  const [cosmetics, setCosmetics] = useState(0);
+  const [vacations, setVacations] = useState([]);
+  const [payouts, setPayouts] = useState([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      const bRes = await api.get('birthdays/', { params: { days: 365 } });
+      setBirthday(bRes.data[0] || null);
+      const today = new Date().toISOString().slice(0, 10);
+      const sRes = await api.get('analytics/sales/details', {
+        params: { date_from: today, date_to: today, page_size: 1 },
+      });
+      setCosmetics(sRes.data.total || 0);
+      const vRes = await api.get('vacations/active');
+      setVacations(vRes.data);
+      const pRes = await api.get('payouts/active');
+      setPayouts(pRes.data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function formatDateRu(value) {
+    if (!value) return '';
+    return new Date(value).toLocaleDateString('ru-RU');
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl mx-auto">
+      <h2 className="text-2xl font-semibold">Дашборд</h2>
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">Ближайший день рождения</h3>
+        {birthday ? (
+          <div className="bg-white border rounded shadow p-3">
+            <div>{birthday.full_name}</div>
+            <div>{formatDateRu(birthday.birthdate)}</div>
+          </div>
+        ) : (
+          <div>Нет данных</div>
+        )}
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">Продажи косметики сегодня</h3>
+        <div className="bg-white border rounded shadow p-3">
+          {cosmetics} ₽
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">Сотрудники в отпуске</h3>
+        {vacations.length ? (
+          <ul className="list-disc ml-4">
+            {vacations.map((v) => (
+              <li key={v.id}>{v.name}</li>
+            ))}
+          </ul>
+        ) : (
+          <div>Нет</div>
+        )}
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">Активные запросы на выплату</h3>
+        {payouts.length ? (
+          <ul className="list-disc ml-4">
+            {payouts.map((p) => (
+              <li key={p.id}>
+                {p.name} — {p.amount} ₽
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div>Нет</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin_frontend/src/pages/Employees.jsx
+++ b/admin_frontend/src/pages/Employees.jsx
@@ -12,6 +12,7 @@ import UpcomingBirthdays from '../components/UpcomingBirthdays.jsx';
 export default function Employees() {
   const emptyForm = {
     id: '',
+    id_original: '',
     name: '',
     full_name: '',
     phone: '',
@@ -65,12 +66,12 @@ export default function Employees() {
   }
 
   function startCreate() {
-    setForm(emptyForm);
+    setForm({ ...emptyForm, id_original: '' });
     setShowForm(true);
   }
 
   function startEdit(emp) {
-    setForm({ ...emp, id: emp.id });
+    setForm({ ...emp, id: emp.id, id_original: emp.id });
     setShowForm(true);
   }
 
@@ -107,8 +108,8 @@ export default function Employees() {
       is_admin: form.is_admin,
     };
     try {
-      if (form.id) {
-        await api.put(`employees/${form.id}`, payload);
+      if (form.id_original) {
+        await api.put(`employees/${form.id_original}`, { id: form.id, ...payload });
       } else {
         payload.id = form.id || Date.now().toString();
         await api.post('employees/', payload);
@@ -269,7 +270,6 @@ export default function Employees() {
               className="border p-2 w-full"
               placeholder="ID"
               value={form.id}
-              disabled={!!form.id}
               onChange={(e) => setForm({ ...form, id: e.target.value })}
             />
             <input

--- a/app/schemas/employee.py
+++ b/app/schemas/employee.py
@@ -24,7 +24,7 @@ class EmployeeCreate(EmployeeBase):
 
 
 class EmployeeUpdate(EmployeeBase):
-    pass
+    id: Optional[str] = None
 
 
 class EmployeeOut(EmployeeBase):

--- a/app/services/employee_service.py
+++ b/app/services/employee_service.py
@@ -48,10 +48,20 @@ class EmployeeService:
         emp = self.get_employee(employee_id)
         if not emp:
             return None
+        new_id = updates.pop("id", None)
         for key, value in updates.items():
             if hasattr(emp, key) and value is not None:
                 setattr(emp, key, value)
-        self._repo.update_employee(emp)
+        if new_id and new_id != emp.id:
+            if any(e.id == str(new_id) for e in self._employees):
+                raise ValueError("employee_exists")
+            self._repo.delete_employee_by_id(emp.id)
+            emp.id = str(new_id)
+            if str(emp.id).isdigit():
+                self._counter = max(self._counter, int(emp.id))
+            self._repo.add_employee(emp)
+        else:
+            self._repo.update_employee(emp)
         return emp
 
     def remove_employee(self, employee_id: str) -> None:
@@ -101,7 +111,10 @@ class EmployeeAPIService:
             self,
             employee_id: str,
             data: EmployeeUpdate) -> EmployeeOut:
-        emp = self.service.update_employee(employee_id, **data.dict())
+        try:
+            emp = self.service.update_employee(employee_id, **data.dict())
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Employee already exists")
         if not emp:
             raise HTTPException(status_code=404, detail="Employee not found")
         return EmployeeOut(**emp.__dict__)


### PR DESCRIPTION
## Summary
- allow editing employee `id` via API and frontend
- include optional `id` in `EmployeeUpdate` schema
- add dashboard page with info on birthdays, cosmetics sales, vacations, and payout requests
- link dashboard as default page in navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e118955a88329bec7ef097108a671