### PR TITLE
Revamp admin UI styling

### DIFF
--- a/admin_frontend/src/App.jsx
+++ b/admin_frontend/src/App.jsx
@@ -18,7 +18,7 @@ import Navigation from './components/Navigation.jsx';
 export default function App() {
   return (
     <Router>
-      <div className="mx-auto max-w-full p-4 space-y-6">
+      <div className="mx-auto max-w-7xl p-6 space-y-8">
         <Navigation />
         <Routes>
           <Route path="/admin" element={<Dashboard />} />

--- a/admin_frontend/src/components/Navigation.jsx
+++ b/admin_frontend/src/components/Navigation.jsx
@@ -52,7 +52,7 @@ export default function Navigation() {
       <button
         type="button"
         onClick={toggle}
-        className="sm:hidden p-2 mb-2 bg-white rounded shadow"
+        className="sm:hidden p-2 mb-2 bg-primary-600 text-white rounded shadow-lg"
       >
         {open ? <X size={20} /> : <Menu size={20} />}
       </button>
@@ -67,21 +67,21 @@ export default function Navigation() {
       <nav
         className={`${
           open ? 'translate-x-0' : '-translate-x-full'
-        } sm:translate-x-0 transition-transform sm:flex flex-wrap gap-2 fixed sm:static top-0 left-0 h-full sm:h-auto w-64 sm:w-auto bg-white p-3 rounded sm:rounded-none shadow`}
+        } sm:translate-x-0 transition-transform sm:flex flex-wrap gap-2 fixed sm:static top-0 left-0 h-full sm:h-auto w-64 sm:w-auto bg-white/80 backdrop-blur-lg p-4 rounded sm:rounded-none shadow-lg`}
       >
         {navStructure.map((cat) => (
           <div key={cat.name} className="relative group">
             <button
               type="button"
-              className="px-3 py-2 bg-blue-50 hover:bg-blue-100 rounded flex items-center"
+              className="px-3 py-2 rounded flex items-center text-gray-700 hover:bg-primary-50 transition-colors"
             >
               {cat.name}
             </button>
-            <div className="absolute z-10 hidden group-hover:block bg-white border rounded shadow mt-1">
+            <div className="absolute z-10 hidden group-hover:block bg-white/90 backdrop-blur border rounded shadow mt-1">
               {cat.items.map((item) => (
                 <Link
                   key={item.to}
-                  className="block px-3 py-2 whitespace-nowrap hover:bg-blue-100"
+                  className="block px-3 py-2 whitespace-nowrap hover:bg-primary-50"
                   to={item.to}
                   onClick={close}
                 >

--- a/admin_frontend/src/index.css
+++ b/admin_frontend/src/index.css
@@ -1,10 +1,34 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
   margin: 0;
-  background: #f3f4f6;
-  color: #111827;
-  font-family: Arial, sans-serif;
+  background: linear-gradient(to bottom right, #e0f2fe, #f9fafb);
+  color: #1f2937;
+  font-family: 'Inter', sans-serif;
+}
+
+@layer base {
+  input,
+  select,
+  textarea {
+    @apply border rounded-md p-2 bg-white/80 backdrop-blur-sm;
+  }
+}
+
+@layer components {
+  .btn {
+    @apply inline-flex items-center gap-1 rounded-md bg-primary-600 text-white px-4 py-2 hover:bg-primary-700 transition-colors;
+  }
+
+  .input {
+    @apply border rounded-md p-2 bg-white/80 backdrop-blur-sm;
+  }
+
+  .card {
+    @apply bg-white/70 backdrop-blur border rounded-lg shadow p-4;
+  }
 }

--- a/admin_frontend/src/pages/Analytics.jsx
+++ b/admin_frontend/src/pages/Analytics.jsx
@@ -147,16 +147,10 @@ export default function Analytics() {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Аналитика продаж</h1>
-      <button
-        className="bg-blue-600 text-white px-3 py-2 rounded"
-        onClick={() => load(true)}
-      >
+      <button className="btn" onClick={() => load(true)}>
         Обновить
       </button>
-      <button
-        className="bg-indigo-600 text-white px-3 py-2 rounded ml-2"
-        onClick={() => loadDetails()}
-      >
+      <button className="btn ml-2" onClick={() => loadDetails()}>
         Аналитика продаж
       </button>
 
@@ -253,10 +247,7 @@ export default function Analytics() {
               <option value="employee">По сотруднику</option>
               <option value="cost">По сумме</option>
             </select>
-            <button
-              className="bg-blue-600 text-white px-3 py-2 rounded"
-              onClick={() => loadDetails()}
-            >
+            <button className="btn" onClick={() => loadDetails()}>
               Фильтр
             </button>
           </div>
@@ -311,10 +302,7 @@ export default function Analytics() {
                   setRatingRange({ ...ratingRange, to: e.target.value })
                 }
               />
-              <button
-                className="bg-blue-600 text-white px-3 py-2 rounded"
-                onClick={loadRating}
-              >
+              <button className="btn" onClick={loadRating}>
                 Показать
               </button>
             </div>

--- a/admin_frontend/src/pages/AnalyticsDetails.jsx
+++ b/admin_frontend/src/pages/AnalyticsDetails.jsx
@@ -49,7 +49,7 @@ export default function AnalyticsDetails() {
           value={period.to}
           onChange={(e) => setPeriod({ ...period, to: e.target.value })}
         />
-        <button onClick={load} className="bg-blue-600 text-white px-3 py-2 rounded">
+        <button onClick={load} className="btn">
           Показать
         </button>
       </div>

--- a/admin_frontend/src/pages/Assets.jsx
+++ b/admin_frontend/src/pages/Assets.jsx
@@ -144,10 +144,10 @@ export default function Assets() {
         </select>
         <input type="date" className="border p-2" value={filters.dateFrom} onChange={(e) => setFilters({ ...filters, dateFrom: e.target.value })} />
         <input type="date" className="border p-2" value={filters.dateTo} onChange={(e) => setFilters({ ...filters, dateTo: e.target.value })} />
-        <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={load}>
+        <button className="btn" onClick={load}>
           Применить
         </button>
-        <button className="bg-indigo-600 text-white px-3 py-2 rounded ml-auto" onClick={startCreate}>
+        <button className="btn ml-auto" onClick={startCreate}>
           <Plus size={16} /> Добавить запись
         </button>
       </div>
@@ -259,10 +259,10 @@ export default function Assets() {
             <input type="date" className="border p-2 w-full" value={form.return_date} onChange={(e) => setForm({ ...form, return_date: e.target.value })} />
             <input type="number" className="border p-2 w-full" placeholder="Срок службы (мес.)" value={form.service_life} onChange={(e) => setForm({ ...form, service_life: Number(e.target.value) })} />
             <div className="flex justify-end gap-2 pt-2">
-              <button className="bg-gray-300 px-3 py-1 rounded" onClick={() => setShowForm(false)}>
+              <button className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={() => setShowForm(false)}>
                 Отмена
               </button>
-              <button className="bg-blue-600 text-white px-3 py-1 rounded" onClick={saveForm}>
+              <button className="btn" onClick={saveForm}>
                 Сохранить
               </button>
             </div>

--- a/admin_frontend/src/pages/Broadcast.jsx
+++ b/admin_frontend/src/pages/Broadcast.jsx
@@ -86,10 +86,7 @@ export default function Broadcast() {
       </div>
 
       <div className="flex flex-wrap gap-3">
-        <button
-          onClick={() => sendAll()}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded shadow hover:bg-blue-700"
-        >
+        <button onClick={() => sendAll()} className="btn shadow">
           <Send size={16} /> Отправить всем
         </button>
 
@@ -108,17 +105,11 @@ export default function Broadcast() {
           ))}
         </select>
 
-        <button
-          onClick={sendOne}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded shadow hover:bg-green-700"
-        >
+        <button onClick={sendOne} className="btn bg-green-600 hover:bg-green-700 shadow">
           <User size={16} /> Отправить выбранным
         </button>
 
-        <button
-          onClick={() => sendAll('test')}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded shadow hover:bg-purple-700"
-        >
+        <button onClick={() => sendAll('test')} className="btn bg-purple-600 hover:bg-purple-700 shadow">
           <Send size={16} /> Тест
         </button>
       </div>

--- a/admin_frontend/src/pages/Dictionary.jsx
+++ b/admin_frontend/src/pages/Dictionary.jsx
@@ -77,7 +77,7 @@ export default function Dictionary() {
             />
           </section>
         ))}
-        <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">
+        <button type="submit" className="btn">
           Сохранить
         </button>
       </form>

--- a/admin_frontend/src/pages/Employees.jsx
+++ b/admin_frontend/src/pages/Employees.jsx
@@ -173,19 +173,19 @@ export default function Employees() {
       <UpcomingBirthdays />
       <div className="flex flex-wrap gap-2 items-center">
         <input
-          className="border p-2 flex-grow"
+          className="input flex-grow"
           placeholder="Фильтр по ФИО"
           value={filterName}
           onChange={(e) => setFilterName(e.target.value)}
         />
         <input
-          className="border p-2 flex-grow"
+          className="input flex-grow"
           placeholder="Фильтр по телефону"
           value={filterPhone}
           onChange={(e) => setFilterPhone(e.target.value)}
         />
         <select
-          className="border p-2"
+          className="input"
           value={sort}
           onChange={(e) => setSort(e.target.value)}
         >
@@ -193,20 +193,14 @@ export default function Employees() {
           <option value="name">По имени</option>
           <option value="position">По должности</option>
         </select>
-        <button
-          className="bg-indigo-600 text-white px-4 py-2 rounded-xl flex items-center gap-1"
-          onClick={downloadPdf}
-        >
+        <button className="btn" onClick={downloadPdf}>
           <FileDown size={16} /> Экспорт PDF
         </button>
-        <button
-          className="bg-blue-600 text-white px-4 py-2 rounded-xl flex items-center gap-1"
-          onClick={startCreate}
-        >
+        <button className="btn" onClick={startCreate}>
           <UserPlus size={16} /> Добавить сотрудника
         </button>
         <button
-          className="bg-red-600 text-white px-4 py-2 rounded-xl flex items-center gap-1 disabled:opacity-50"
+          className="btn bg-red-600 hover:bg-red-700 disabled:opacity-50"
           disabled={!selected.length}
           onClick={deleteSelected}
         >
@@ -305,48 +299,48 @@ export default function Employees() {
 
       {showForm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-4 space-y-2 rounded shadow w-80">
+          <div className="card space-y-2 w-80">
             <h2 className="text-lg font-bold mb-2">
               {form.id ? 'Редактирование' : 'Новый сотрудник'}
             </h2>
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="ID"
               value={form.id}
               onChange={(e) => setForm({ ...form, id: e.target.value })}
             />
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Имя"
               value={form.name}
               onChange={(e) => setForm({ ...form, name: e.target.value })}
             />
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="ФИО"
               value={form.full_name}
               onChange={(e) => setForm({ ...form, full_name: e.target.value })}
             />
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Телефон"
               value={form.phone}
               onChange={(e) => setForm({ ...form, phone: e.target.value })}
             />
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Номер карты"
               value={form.card_number}
               onChange={(e) => setForm({ ...form, card_number: e.target.value })}
             />
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Банк"
               value={form.bank}
               onChange={(e) => setForm({ ...form, bank: e.target.value })}
             />
             <select
-              className="border p-2 w-full"
+              className="input w-full"
               value={form.position}
               onChange={(e) => setForm({ ...form, position: e.target.value })}
             >
@@ -358,7 +352,7 @@ export default function Employees() {
               ))}
             </select>
             <select
-              className="border p-2 w-full"
+              className="input w-full"
               value={form.work_place}
               onChange={(e) => setForm({ ...form, work_place: e.target.value })}
             >
@@ -370,25 +364,25 @@ export default function Employees() {
               ))}
             </select>
             <input
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Размер формы"
               value={form.clothing_size}
               onChange={(e) => setForm({ ...form, clothing_size: e.target.value })}
             />
             <input
               type="date"
-              className="border p-2 w-full"
+              className="input w-full"
               value={form.birthdate}
               onChange={(e) => setForm({ ...form, birthdate: e.target.value })}
             />
             <textarea
-              className="border p-2 w-full"
+              className="input w-full"
               placeholder="Заметка"
               value={form.note}
               onChange={(e) => setForm({ ...form, note: e.target.value })}
             />
             <select
-              className="border p-2 w-full"
+              className="input w-full"
               value={form.status}
               onChange={(e) => setForm({ ...form, status: e.target.value })}
             >
@@ -415,10 +409,10 @@ export default function Employees() {
             </label>
             <input type="file" onChange={handleFile} />
             <div className="flex justify-end gap-2 pt-2">
-              <button className="bg-gray-300 px-3 py-1 rounded-xl" onClick={() => setShowForm(false)}>
+              <button className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={() => setShowForm(false)}>
                 Отмена
               </button>
-              <button className="bg-blue-600 text-white px-3 py-1 rounded-xl" onClick={saveForm}>
+              <button className="btn" onClick={saveForm}>
                 Сохранить
               </button>
             </div>

--- a/admin_frontend/src/pages/Incentives.jsx
+++ b/admin_frontend/src/pages/Incentives.jsx
@@ -137,10 +137,10 @@ export default function Incentives() {
           value={filters.to}
           onChange={(e) => setFilters({ ...filters, to: e.target.value })}
         />
-        <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={load}>
+        <button className="btn" onClick={load}>
           Применить
         </button>
-        <button className="bg-indigo-600 text-white px-3 py-2 rounded ml-auto" onClick={startCreate}>
+        <button className="btn ml-auto" onClick={startCreate}>
           ➕ Добавить
         </button>
       </div>
@@ -242,10 +242,10 @@ export default function Incentives() {
               onChange={(e) => setForm({ ...form, reason: e.target.value })}
             />
             <div className="flex justify-end gap-2 pt-2">
-              <button className="bg-gray-300 px-3 py-1 rounded" onClick={() => setShowForm(false)}>
+              <button className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={() => setShowForm(false)}>
                 Отмена
               </button>
-              <button className="bg-blue-600 text-white px-3 py-1 rounded" onClick={saveForm}>
+              <button className="btn" onClick={saveForm}>
                 Сохранить
               </button>
             </div>

--- a/admin_frontend/src/pages/Payouts.jsx
+++ b/admin_frontend/src/pages/Payouts.jsx
@@ -455,19 +455,13 @@ export default function Payouts() {
           value={filters.to}
           onChange={(e) => setFilters({ ...filters, to: e.target.value })}
         />
-        <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={load}>
+        <button className="btn" onClick={load}>
           Применить
         </button>
-        <button
-          className="bg-gray-300 px-3 py-2 rounded"
-          onClick={resetFilters}
-        >
+        <button className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={resetFilters}>
           Сбросить
         </button>
-        <button
-          className="bg-indigo-600 text-white px-3 py-2 rounded ml-auto"
-          onClick={openCreate}
-        >
+        <button className="btn ml-auto" onClick={openCreate}>
           ➕ Новая
         </button>
       </div>
@@ -562,10 +556,7 @@ export default function Payouts() {
       </div>
 
       <div className="flex gap-3 items-center">
-        <button
-          onClick={exportPdf}
-          className="bg-green-600 text-white px-3 py-2 rounded flex items-center gap-1"
-        >
+        <button onClick={exportPdf} className="btn bg-green-600 hover:bg-green-700 flex items-center gap-1">
           <Download size={16} /> PDF
         </button>
       </div>
@@ -677,7 +668,7 @@ export default function Payouts() {
             </label>
             <div className="flex justify-end space-x-2 pt-2">
               <button
-                className="bg-gray-300 px-3 py-1 rounded"
+                className="btn bg-gray-300 text-gray-700 hover:bg-gray-400"
                 onClick={() => {
                   setShowEditor(false);
                   setForm(emptyForm);
@@ -685,10 +676,7 @@ export default function Payouts() {
               >
                 Отмена
               </button>
-              <button
-                className="bg-blue-600 text-white px-3 py-1 rounded"
-                onClick={saveForm}
-              >
+              <button className="btn" onClick={saveForm}>
                 Сохранить
               </button>
             </div>

--- a/admin_frontend/src/pages/PayoutsControl.jsx
+++ b/admin_frontend/src/pages/PayoutsControl.jsx
@@ -117,10 +117,7 @@ export default function PayoutsControl() {
           value={filters.to}
           onChange={(e) => setFilters({ ...filters, to: e.target.value })}
         />
-        <button
-          className="bg-blue-600 text-white px-3 py-2 rounded"
-          onClick={load}
-        >
+        <button className="btn" onClick={load}>
           Применить
         </button>
         <div className="flex flex-wrap gap-2 border border-gray-300 rounded p-2 bg-gray-50 text-xs">

--- a/admin_frontend/src/pages/Reports.jsx
+++ b/admin_frontend/src/pages/Reports.jsx
@@ -21,10 +21,7 @@ export default function Reports() {
       <h2 className="text-2xl font-semibold tracking-tight text-gray-800 flex items-center gap-2">
         <Download size={24} /> Отчёты
       </h2>
-      <button
-        onClick={downloadReport}
-        className="bg-indigo-600 text-white px-4 py-2 rounded"
-      >
+      <button onClick={downloadReport} className="btn">
         📄 Скачать отчёт
       </button>
     </div>

--- a/admin_frontend/src/pages/Settings.jsx
+++ b/admin_frontend/src/pages/Settings.jsx
@@ -109,8 +109,8 @@ export default function Settings() {
           <input className="border p-2 w-full" placeholder="Vacations" {...register('vacations_file_path')} />
         </section>
         <div className="flex gap-3">
-          <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">Сохранить</button>
-          <button type="button" className="bg-gray-300 px-3 py-2 rounded" onClick={downloadConfig}>Скачать</button>
+          <button type="submit" className="btn">Сохранить</button>
+          <button type="button" className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={downloadConfig}>Скачать</button>
           <input type="file" onChange={uploadConfig} />
         </div>
       </form>

--- a/admin_frontend/src/pages/Vacations.jsx
+++ b/admin_frontend/src/pages/Vacations.jsx
@@ -179,10 +179,10 @@ export default function Vacations() {
           value={filters.query}
           onChange={(e) => setFilters({ ...filters, query: e.target.value })}
         />
-        <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={load}>
+        <button className="btn" onClick={load}>
           Применить
         </button>
-        <button className="bg-indigo-600 text-white px-3 py-2 rounded ml-auto" onClick={startCreate}>
+        <button className="btn ml-auto" onClick={startCreate}>
           <Plus size={16} /> Добавить запись
         </button>
       </div>
@@ -376,10 +376,10 @@ export default function Vacations() {
               onChange={(e) => setForm({ ...form, comment: e.target.value })}
             />
             <div className="flex justify-end gap-2 pt-2">
-              <button className="bg-gray-300 px-3 py-1 rounded" onClick={() => setShowForm(false)}>
+              <button className="btn bg-gray-300 text-gray-700 hover:bg-gray-400" onClick={() => setShowForm(false)}>
                 Отмена
               </button>
-              <button className="bg-blue-600 text-white px-3 py-1 rounded" onClick={saveForm}>
+              <button className="btn" onClick={saveForm}>
                 Сохранить
               </button>
             </div>

--- a/admin_frontend/tailwind.config.js
+++ b/admin_frontend/tailwind.config.js
@@ -1,10 +1,18 @@
+import colors from 'tailwindcss/colors';
+import { fontFamily } from 'tailwindcss/defaultTheme';
+
 export default {
-  content: [
-    './index.html',
-    './src/**/*.{js,jsx,ts,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: colors.indigo,
+        secondary: colors.pink,
+      },
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- integrate Inter font and gradient background
- add base styling for inputs, buttons and cards
- implement new primary color palette
- modernize navigation and pages to use new styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f6a7a1848329b7472372412ed2ad