### PR TITLE
Add REF UI demo page

### DIFF
--- a/admin_frontend/package-lock.json
+++ b/admin_frontend/package-lock.json
@@ -8,12 +8,17 @@
       "name": "admin_frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.1.2",
         "axios": "^1.10.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^1.2.1",
+        "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.50.0",
         "react-router-dom": "^7.6.2",
-        "tailwindcss": "^3.4.1",
-        "react-hook-form": "^7.50.0"
+        "tailwind-merge": "^2.2.1",
+        "tailwindcss": "^3.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1105,6 +1110,39 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -1455,7 +1493,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1838,6 +1876,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1930,7 +1998,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2973,6 +3041,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3521,6 +3598,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+      "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3923,6 +4016,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/admin_frontend/package.json
+++ b/admin_frontend/package.json
@@ -16,7 +16,11 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "tailwindcss": "^3.4.1",
-    "react-hook-form": "^7.50.0"
+    "react-hook-form": "^7.50.0",
+    "clsx": "^1.2.1",
+    "tailwind-merge": "^2.2.1",
+    "class-variance-authority": "^0.7.1",
+    "@radix-ui/react-slot": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/admin_frontend/src/App.jsx
+++ b/admin_frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Birthdays from './pages/Birthdays';
 import Settings from './pages/Settings';
 import Assets from './pages/Assets';
 import Dictionary from './pages/Dictionary';
+import RefDashboard from './pages/RefDashboard';
 import MainLayout from './layouts/MainLayout.jsx';
 import PlainLayout from './layouts/PlainLayout.jsx';
 
@@ -35,6 +36,7 @@ export default function App() {
           <Route path="assets" element={<Assets />} />
           <Route path="dictionary" element={<Dictionary />} />
           <Route path="settings" element={<Settings />} />
+          <Route path="ref" element={<RefDashboard />} />
         </Route>
         <Route path="*" element={<PlainLayout />}> 
           <Route index element={<Navigate to="/admin" replace />} />

--- a/admin_frontend/src/pages/RefDashboard.jsx
+++ b/admin_frontend/src/pages/RefDashboard.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ref_ui/card';
+import { Button } from '../ref_ui/button';
+import { StatusBadge } from '../ref_ui/StatusBadge';
+import api from '../api';
+
+export default function RefDashboard() {
+  const [count, setCount] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      const res = await api.get('employees/');
+      setCount(res.data.length);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function refresh() {
+    setLoading(true);
+    await load();
+    setLoading(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Сотрудники</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2">
+          {count === null ? 'Загрузка...' : <span>Всего сотрудников: {count}</span>}
+          {loading && <StatusBadge status="processing" size="sm" />}
+        </CardContent>
+      </Card>
+      <Button onClick={refresh}>Обновить</Button>
+    </div>
+  );
+}

--- a/admin_frontend/src/ref_ui/ActionCard.jsx
+++ b/admin_frontend/src/ref_ui/ActionCard.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from './card';
+import { Button } from './button';
+import { cn } from './utils';
+
+export function ActionCard({
+  title,
+  description,
+  icon,
+  actions = [],
+  variant = 'default',
+  children,
+  className,
+}) {
+  const variantClasses = {
+    default: 'border border-border-light',
+    compact: 'border border-border-light p-4',
+    highlighted: 'border-2 border-primary bg-primary/5',
+  };
+
+  return (
+    <Card className={cn(variantClasses[variant], className)}>
+      <CardHeader className={variant === 'compact' ? 'p-0 pb-3' : undefined}>
+        <CardTitle className="flex items-center gap-3">
+          {icon && <div className="text-primary">{icon}</div>}
+          <div>
+            <div>{title}</div>
+            {description && <div className="text-sm text-text-secondary font-normal mt-1">{description}</div>}
+          </div>
+        </CardTitle>
+      </CardHeader>
+      {children && <CardContent className={variant === 'compact' ? 'p-0 py-3' : undefined}>{children}</CardContent>}
+      {actions.length > 0 && (
+        <CardContent className={cn('flex gap-2 pt-0', variant === 'compact' ? 'p-0 pt-3' : undefined)}>
+          {actions.map((action, index) => (
+            <Button
+              key={index}
+              variant={action.variant || 'default'}
+              size="sm"
+              onClick={action.onClick}
+              disabled={action.disabled}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/admin_frontend/src/ref_ui/StatusBadge.jsx
+++ b/admin_frontend/src/ref_ui/StatusBadge.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Badge } from './badge';
+import { cn } from './utils';
+
+const statusConfig = {
+  approved: {
+    label: 'Одобрено',
+    className: 'bg-success text-success-foreground border-success',
+    emoji: '✅',
+  },
+  rejected: {
+    label: 'Отклонено',
+    className: 'bg-danger text-danger-foreground border-danger',
+    emoji: '❌',
+  },
+  waiting: {
+    label: 'Ожидание',
+    className: 'bg-warning text-warning-foreground border-warning',
+    emoji: '⏳',
+  },
+  active: {
+    label: 'Активен',
+    className: 'bg-success text-success-foreground border-success',
+    emoji: '🟢',
+  },
+  inactive: {
+    label: 'Неактивен',
+    className: 'bg-muted text-muted-foreground border-muted',
+    emoji: '⚫',
+  },
+  processing: {
+    label: 'Обработка',
+    className: 'bg-primary text-primary-foreground border-primary',
+    emoji: '🔄',
+  },
+};
+
+export function StatusBadge({ status, size = 'md', variant = 'default' }) {
+  const config = statusConfig[status] || statusConfig.waiting;
+  const sizeClasses = { sm: 'text-xs px-2 py-1', md: 'text-sm px-3 py-1.5', lg: 'text-base px-4 py-2' };
+  return (
+    <Badge
+      variant={variant}
+      className={cn(
+        sizeClasses[size],
+        variant === 'default' && config.className,
+        variant === 'outline' && 'border-2',
+        'inline-flex items-center gap-1 font-medium'
+      )}
+    >
+      <span>{config.emoji}</span>
+      {config.label}
+    </Badge>
+  );
+}

--- a/admin_frontend/src/ref_ui/badge.jsx
+++ b/admin_frontend/src/ref_ui/badge.jsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva } from 'class-variance-authority';
+import { cn } from './utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive: 'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Badge({ className, variant, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : 'span';
+  return <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/admin_frontend/src/ref_ui/button.jsx
+++ b/admin_frontend/src/ref_ui/button.jsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva } from 'class-variance-authority';
+import { cn } from './utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+function Button({ className, variant, size, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />
+  );
+}
+
+export { Button, buttonVariants };

--- a/admin_frontend/src/ref_ui/card.jsx
+++ b/admin_frontend/src/ref_ui/card.jsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+function Card({ className, ...props }) {
+  return (
+    <div data-slot="card" className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border', className)} {...props} />
+  );
+}
+
+function CardHeader({ className, ...props }) {
+  return (
+    <div data-slot="card-header" className={cn('@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6', className)} {...props} />
+  );
+}
+
+function CardTitle({ className, ...props }) {
+  return <h4 data-slot="card-title" className={cn('leading-none', className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }) {
+  return <p data-slot="card-description" className={cn('text-muted-foreground', className)} {...props} />;
+}
+
+function CardAction({ className, ...props }) {
+  return (
+    <div data-slot="card-action" className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)} {...props} />
+  );
+}
+
+function CardContent({ className, ...props }) {
+  return <div data-slot="card-content" className={cn('px-6 [&:last-child]:pb-6', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 pb-6 [.border-t]:pt-6', className)} {...props} />;
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/admin_frontend/src/ref_ui/input.jsx
+++ b/admin_frontend/src/ref_ui/input.jsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+function Input({ className, type, ...props }) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/admin_frontend/src/ref_ui/utils.js
+++ b/admin_frontend/src/ref_ui/utils.js
@@ -1,0 +1,5 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add ShadCN-style React components
- expose new /admin/ref route to demo integration
- build frontend after install

## Testing
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688373b2568c8329b4c3e46fbb7d2f15