### PR TITLE
Fix API logs in admin frontend

### DIFF
--- a/admin_frontend/src/api.js
+++ b/admin_frontend/src/api.js
@@ -6,11 +6,15 @@ const api = axios.create({
 
 api.interceptors.response.use(
   (response) => {
-    console.log('API', response.config?.url, response.data);
+    if (import.meta.env.DEV) {
+      console.log('API', response.config?.url, response.data);
+    }
     return response;
   },
   (error) => {
-    console.error('API', error.config?.url, error.message);
+    if (import.meta.env.DEV) {
+      console.error('API', error.config?.url, error.message);
+    }
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## Summary
- wrap logging in admin frontend with environment check

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688383f4d5588329bc59b1560b628961