### PR TITLE
Update HR Portal layout and colors

### DIFF
--- a/admin_frontend/src/components/Navigation.jsx
+++ b/admin_frontend/src/components/Navigation.jsx
@@ -1,45 +1,20 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 
-const navStructure = [
-  {
-    name: 'Обзор',
-    items: [{ to: '/admin', label: 'Дашборд' }],
-  },
-  {
-    name: 'Персонал',
-    items: [
-      { to: '/admin/employees', label: 'Сотрудники' },
-      { to: '/admin/vacations', label: 'Отпуска' },
-      { to: '/admin/birthdays', label: 'Дни рождения' },
-      { to: '/admin/assets', label: 'Имущество' },
-    ],
-  },
-  {
-    name: 'Финансы',
-    items: [
-      { to: '/admin/payouts', label: 'Выплаты' },
-      { to: '/admin/payouts-control', label: 'Контроль выплат' },
-      { to: '/admin/incentives', label: 'Штрафы и премии' },
-    ],
-  },
-  {
-    name: 'Аналитика',
-    items: [
-      { to: '/admin/reports', label: 'Отчёты' },
-      { to: '/admin/analytics', label: 'Аналитика' },
-      { to: '/admin/analytics-details', label: 'Подробная аналитика' },
-    ],
-  },
-  {
-    name: 'Управление',
-    items: [
-      { to: '/admin/broadcast', label: 'Рассылка' },
-      { to: '/admin/dictionary', label: 'Словарь' },
-      { to: '/admin/settings', label: 'Настройки' },
-    ],
-  },
+const navItems = [
+  { to: '/admin', label: 'Дашборд' },
+  { to: '/admin/employees', label: 'Сотрудники' },
+  { to: '/admin/vacations', label: 'Отпуска' },
+  { to: '/admin/assets', label: 'Имущество' },
+  { to: '/admin/broadcast', label: 'Рассылка' },
+  { to: '/admin/analytics', label: 'Аналитика' },
+  { to: '/admin/incentives', label: 'Штрафы/Премии' },
+  { to: '/admin/payouts', label: 'Выплаты' },
+  { to: '/admin/payouts-control', label: 'Контроль' },
+  { to: '/admin/birthdays', label: 'Дни рождения' },
+  { to: '/admin/dictionary', label: 'Словарь' },
+  { to: '/admin/settings', label: 'Настройки' },
 ];
 
 export default function Navigation() {
@@ -48,7 +23,7 @@ export default function Navigation() {
   const close = () => setOpen(false);
 
   return (
-    <div className="relative mb-4">
+    <div className="relative">
       <button
         type="button"
         onClick={toggle}
@@ -56,40 +31,29 @@ export default function Navigation() {
       >
         {open ? <X size={20} /> : <Menu size={20} />}
       </button>
-
       {open && (
-        <div
-          className="fixed inset-0 bg-black/50 sm:hidden"
-          onClick={close}
-        />
+        <div className="fixed inset-0 bg-black/50 sm:hidden" onClick={close} />
       )}
-
       <nav
         className={`${
-          open ? 'translate-x-0' : '-translate-x-full'
-        } sm:translate-x-0 transition-transform sm:flex flex-wrap gap-2 fixed sm:static top-0 left-0 h-full sm:h-auto w-64 sm:w-auto bg-white/80 backdrop-blur-lg p-4 rounded sm:rounded-none shadow-lg`}
+          open ? 'flex' : 'hidden'
+        } sm:flex flex-wrap items-center gap-4 absolute sm:static top-full left-0 bg-white sm:bg-transparent shadow sm:shadow-none p-4 sm:p-0 w-full`}
       >
-        {navStructure.map((cat) => (
-          <div key={cat.name} className="relative group">
-            <button
-              type="button"
-              className="px-3 py-2 rounded flex items-center text-gray-700 hover:bg-muted/20 transition-colors"
-            >
-              {cat.name}
-            </button>
-            <div className="absolute z-10 hidden group-hover:block bg-white/90 backdrop-blur border rounded shadow mt-1">
-              {cat.items.map((item) => (
-                <Link
-                  key={item.to}
-                  className="block px-3 py-2 whitespace-nowrap hover:bg-muted/20"
-                  to={item.to}
-                  onClick={close}
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          </div>
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            onClick={close}
+            className={({ isActive }) =>
+              `px-3 py-2 text-sm font-semibold uppercase border-b-2 ${
+                isActive
+                  ? 'border-brand text-brand'
+                  : 'border-transparent hover:text-brand'
+              }`
+            }
+          >
+            {item.label}
+          </NavLink>
         ))}
       </nav>
     </div>

--- a/admin_frontend/src/index.css
+++ b/admin_frontend/src/index.css
@@ -6,7 +6,7 @@
 
 :root {
   --bg: #FFFFFF;
-  --primary: #FF6600;
+  --primary: #2E75FF;
   --text-main: #333333;
   --text-secondary: #666666;
   --error: #D0021B;

--- a/admin_frontend/src/layouts/MainLayout.jsx
+++ b/admin_frontend/src/layouts/MainLayout.jsx
@@ -3,10 +3,10 @@ import Navigation from '../components/Navigation.jsx';
 
 export default function MainLayout() {
   return (
-    <div className="flex min-h-screen bg-surface text-gray-900 dark:bg-gray-900 dark:text-white">
-      <aside className="w-64 shrink-0 p-4 border-r border-muted/20">
+    <div className="min-h-screen flex flex-col bg-surface text-gray-900 dark:bg-gray-900 dark:text-white">
+      <header className="bg-white shadow p-4">
         <Navigation />
-      </aside>
+      </header>
       <main className="flex-1 p-6">
         <Outlet />
       </main>

--- a/admin_frontend/tailwind.config.js
+++ b/admin_frontend/tailwind.config.js
@@ -6,7 +6,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        brand: { DEFAULT: '#FF6600', dark: '#cc5200' },
+        brand: { DEFAULT: '#2E75FF', dark: '#1f5fcc' },
         surface: '#F9FAFB',
         muted: '#6B7280',
         success: '#10B981',


### PR DESCRIPTION
## Summary
- redesign navigation with a horizontal top bar
- switch brand color from orange to blue
- tweak main layout to use header instead of sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883af6d14288329809956b27bf128c0