### PR TITLE
Fix send_message request schema

### DIFF
--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -7,6 +7,7 @@ class MessageRequest(BaseModel):
     message: str
     parse_mode: str = "HTML"
     require_ack: bool = False
+    photo_url: Optional[str] = None
 
 
 class MessageOut(BaseModel):


### PR DESCRIPTION
## Summary
- allow sending Telegram messages with optional photo URL

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: test_generate_employee_profile_pdf, test_payout_json_fields_match_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68949348dd3483299b34404ddbaafa1b