### PR TITLE
feat: improve broadcast handling

### DIFF
--- a/admin_frontend/src/pages/Broadcast.jsx
+++ b/admin_frontend/src/pages/Broadcast.jsx
@@ -14,6 +14,7 @@ export default function Broadcast() {
   const [showTemplates, setShowTemplates] = useState(false);
   const [tplName, setTplName] = useState('');
   const [tplText, setTplText] = useState('');
+  const [openBroadcast, setOpenBroadcast] = useState(null);
 
   useEffect(() => {
     const saved = localStorage.getItem('broadcast_draft');
@@ -208,29 +209,61 @@ export default function Broadcast() {
       </div>
 
       <div className="mt-8">
-        <h3 className="text-xl font-semibold mb-2">Отправленные сообщения</h3>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-xl font-semibold">Отправленные сообщения</h3>
+          <button onClick={fetchSent} className="btn">Обновить</button>
+        </div>
         <ul className="space-y-2">
           {sent.map((m) => (
-            <li
-              key={m.id}
-              className="p-3 border rounded flex justify-between items-start gap-2"
-            >
-              <div>
-                <div className="font-medium whitespace-pre-wrap">{m.message}</div>
-                <div className="text-xs text-gray-500">
-                  {new Date(m.timestamp).toLocaleString()} —
-                  {" "}
-                  {m.broadcast
-                    ? `broadcast (${m.recipients?.length || 0})`
-                    : m.status}
+            <li key={m.id} className="p-3 border rounded">
+              <div className="flex justify-between items-start gap-2">
+                <div className="flex-1">
+                  {m.broadcast ? (
+                    <button
+                      onClick={() =>
+                        setOpenBroadcast((prev) => (prev === m.id ? null : m.id))
+                      }
+                      className="font-medium text-blue-600 underline"
+                    >
+                      {`Рассылка ${new Date(m.timestamp).toLocaleString()}`}
+                    </button>
+                  ) : (
+                    <>
+                      <div className="font-medium whitespace-pre-wrap">{m.message}</div>
+                      <div className="text-xs text-gray-500">
+                        {new Date(m.timestamp).toLocaleString()} — {m.status}
+                      </div>
+                    </>
+                  )}
                 </div>
+                <button
+                  onClick={() => deleteMessage(m.id)}
+                  className="text-red-600 hover:text-red-800"
+                >
+                  <Trash2 size={16} />
+                </button>
               </div>
-              <button
-                onClick={() => deleteMessage(m.id)}
-                className="text-red-600 hover:text-red-800"
-              >
-                <Trash2 size={16} />
-              </button>
+              {m.broadcast && openBroadcast === m.id && (
+                <div className="mt-2">
+                  <div className="font-medium whitespace-pre-wrap mb-2">{m.message}</div>
+                  <table className="w-full text-sm border">
+                    <thead>
+                      <tr className="bg-gray-100">
+                        <th className="text-left p-1 border">Получатель</th>
+                        <th className="text-left p-1 border">Статус</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {m.recipients?.map((r) => (
+                        <tr key={r.user_id}>
+                          <td className="p-1 border">{r.name}</td>
+                          <td className="p-1 border">{r.status}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -110,6 +110,11 @@ class TelegramService:
         for emp in employees:
             if not is_valid_user_id(emp.id):
                 log(f"⚠️ Skipping message — invalid or fake user_id: {emp.id}")
+                recipients.append({
+                    "user_id": str(emp.id),
+                    "name": emp.full_name or emp.name,
+                    "status": "невалидный id",
+                })
                 continue
             try:
                 personalized = message.format(**emp.__dict__)
@@ -142,9 +147,18 @@ class TelegramService:
                 })
             except BadRequest as exc:
                 log(f"❌ Failed to send broadcast to chat {emp.id} — {exc}")
-                raise
+                recipients.append({
+                    "user_id": str(emp.id),
+                    "name": emp.full_name or emp.name,
+                    "status": f"ошибка: {exc}",
+                })
             except Exception as exc:
                 logger.warning(f"Failed for {emp.id}: {exc}")
+                recipients.append({
+                    "user_id": str(emp.id),
+                    "name": emp.full_name or emp.name,
+                    "status": f"ошибка: {exc}",
+                })
         log_entry = {
             "id": str(uuid4()),
             "broadcast": True,


### PR DESCRIPTION
## Summary
- add refresh and recipient status table to broadcast history
- ignore invalid ids and continue sending broadcast

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c9be3fc08329a931714e5a7f5bb7