### PR TITLE
Add salon analytics page and endpoint

### DIFF
--- a/admin_frontend/src/App.jsx
+++ b/admin_frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Reports from './pages/Reports';
 import Broadcast from './pages/Broadcast';
 import Analytics from './pages/Analytics';
 import AnalyticsDetails from './pages/AnalyticsDetails';
+import AnalyticsSalons from './pages/AnalyticsSalons';
 import Vacations from './pages/Vacations';
 import Birthdays from './pages/Birthdays';
 import Settings from './pages/Settings';
@@ -38,6 +39,7 @@ export default function App() {
           <Route path="birthdays" element={<Birthdays />} />
           <Route path="analytics" element={<Analytics />} />
           <Route path="analytics-details" element={<AnalyticsDetails />} />
+          <Route path="analytics-salons" element={<AnalyticsSalons />} />
           <Route path="assets" element={<Assets />} />
           <Route path="dictionary" element={<Dictionary />} />
           <Route path="settings" element={<Settings />} />

--- a/admin_frontend/src/components/Navigation.jsx
+++ b/admin_frontend/src/components/Navigation.jsx
@@ -25,14 +25,15 @@ const navStructure = [
       { to: '/admin/salary', label: 'Расчёт ЗП' },
     ],
   },
-  {
-    name: 'Аналитика',
-    items: [
-      { to: '/admin/reports', label: 'Отчёты' },
-      { to: '/admin/analytics', label: 'Аналитика' },
-      { to: '/admin/analytics-details', label: 'Подробная аналитика' },
-    ],
-  },
+      {
+        name: 'Аналитика',
+        items: [
+          { to: '/admin/reports', label: 'Отчёты' },
+          { to: '/admin/analytics', label: 'Аналитика' },
+          { to: '/admin/analytics-details', label: 'Подробная аналитика' },
+          { to: '/admin/analytics-salons', label: 'Аналитика по салонам' },
+        ],
+      },
   {
     name: 'Управление',
     items: [

--- a/admin_frontend/src/pages/AnalyticsSalons.jsx
+++ b/admin_frontend/src/pages/AnalyticsSalons.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import api from '../api';
+
+const SALONS = [
+  { code: 'mercury', label: 'Меркурий' },
+  { code: 'okhta', label: 'Охта-Молл' },
+  { code: 'ozerki', label: 'Озерки' },
+  { code: 'passage', label: 'Пассаж' },
+  { code: 'akpark', label: 'Академ Парк' },
+];
+
+export default function AnalyticsSalons() {
+  const [selected, setSelected] = useState(null);
+  const [rows, setRows] = useState([]);
+
+  async function load(code) {
+    try {
+      const res = await api.get('analytics/salons', { params: { salon: code } });
+      setRows(res.data.items || []);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function selectSalon(code) {
+    setSelected(code);
+    load(code);
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Аналитика по салонам</h1>
+      {!selected && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {SALONS.map((s) => (
+            <button
+              key={s.code}
+              className="p-4 bg-white rounded shadow hover:bg-muted/20 transition"
+              onClick={() => selectSalon(s.code)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {selected && (
+        <div className="space-y-4">
+          <button className="btn" onClick={() => setSelected(null)}>
+            Назад
+          </button>
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm bg-white rounded shadow">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="p-2 text-left">Дата</th>
+                  <th className="p-2 text-left">Количество посетителей</th>
+                  <th className="p-2 text-left">Выручка</th>
+                  <th className="p-2 text-left">Количество сделок</th>
+                  <th className="p-2 text-left">RPV</th>
+                  <th className="p-2 text-left">Администратор</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((row, idx) => (
+                  <tr key={idx}>
+                    <td className="p-2">{row.date}</td>
+                    <td className="p-2">{row.visitors}</td>
+                    <td className="p-2">{row.revenue}</td>
+                    <td className="p-2">{row.deals}</td>
+                    <td className="p-2">{row.rpv}</td>
+                    <td className="p-2">{row.admin}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/analytics.py
+++ b/app/api/analytics.py
@@ -78,4 +78,8 @@ def create_analytics_router(service: AnalyticsService) -> APIRouter:
             date_from=date_from, date_to=date_to
         )
 
+    @router.get("/salons")
+    async def get_salon_analytics(salon: str):
+        return {"items": await service.get_salon_analytics(salon)}
+
     return router

--- a/app/config.py
+++ b/app/config.py
@@ -27,6 +27,7 @@ VACATIONS_FILE = settings.vacations_file
 ADJUSTMENTS_FILE = settings.adjustments_file
 BONUSES_PENALTIES_FILE = settings.bonuses_penalties_file
 ASSETS_FILE = settings.assets_file
+SALON_ANALYTICS_FILE = settings.salon_analytics_file
 ADMIN_ID = settings.admin_id
 ADMIN_CHAT_ID = settings.admin_chat_id
 ADMIN_LOGIN = settings.admin_login

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional, Any, List
 import asyncio
 import os
+import json
 
 import pandas as pd
 
@@ -14,6 +15,7 @@ from ..config import (
     FIREBIRD_DB,
     FIREBIRD_USER,
     FIREBIRD_PASSWORD,
+    SALON_ANALYTICS_FILE,
 )
 from openpyxl import load_workbook
 from .firebird_service import FirebirdService
@@ -746,4 +748,15 @@ class AnalyticsService:
             )
 
         return {"items": result}
+
+    async def get_salon_analytics(self, salon: str) -> list[dict[str, Any]]:
+        """Return analytics data for a given salon from JSON file."""
+        path = Path(SALON_ANALYTICS_FILE)
+        if not path.exists():
+            return []
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        return data.get(salon, [])
 

--- a/app/services/firebird_service.py
+++ b/app/services/firebird_service.py
@@ -2,7 +2,10 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
 
-import fdb
+try:
+    import fdb  # type: ignore
+except Exception:  # pragma: no cover
+    fdb = None
 
 from ..utils.logger import log
 
@@ -17,7 +20,9 @@ class FirebirdService:
         self._cache: Dict[Tuple[Any, ...], Tuple[datetime, Any]] = {}
         self._version: str | None = None
 
-    def _connect(self) -> fdb.Connection:
+    def _connect(self) -> 'fdb.Connection':
+        if fdb is None:
+            raise RuntimeError("fdb library is not installed")
         return fdb.connect(dsn=self.dsn, user=self.user, password=self.password)
 
     def test_connection(self) -> bool:

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
         "bonuses_penalties.json", env="BONUSES_PENALTIES_FILE"
     )
     assets_file: str = Field("assets.json", env="ASSETS_FILE")
+    salon_analytics_file: str = Field(
+        "salon_analytics.json", env="SALON_ANALYTICS_FILE"
+    )
     admin_id: int = Field(0, env="ADMIN_ID")
     admin_chat_id: int = Field(5495663985, env="ADMIN_CHAT_ID")
     admin_login: str = Field("admin", env="ADMIN_LOGIN")

--- a/salon_analytics.json
+++ b/salon_analytics.json
@@ -1,0 +1,22 @@
+{
+  "mercury": [
+    {"date": "2024-01-01", "visitors": 120, "revenue": 50000, "deals": 40, "rpv": 417, "admin": "Анна"},
+    {"date": "2024-01-02", "visitors": 110, "revenue": 47000, "deals": 35, "rpv": 427, "admin": "Борис"}
+  ],
+  "okhta": [
+    {"date": "2024-01-01", "visitors": 90, "revenue": 38000, "deals": 28, "rpv": 422, "admin": "Виктор"},
+    {"date": "2024-01-02", "visitors": 95, "revenue": 40000, "deals": 30, "rpv": 421, "admin": "Галина"}
+  ],
+  "ozerki": [
+    {"date": "2024-01-01", "visitors": 75, "revenue": 30000, "deals": 20, "rpv": 400, "admin": "Дмитрий"},
+    {"date": "2024-01-02", "visitors": 80, "revenue": 32000, "deals": 22, "rpv": 400, "admin": "Елена"}
+  ],
+  "passage": [
+    {"date": "2024-01-01", "visitors": 100, "revenue": 45000, "deals": 33, "rpv": 450, "admin": "Жанна"},
+    {"date": "2024-01-02", "visitors": 105, "revenue": 46000, "deals": 34, "rpv": 438, "admin": "Зинаида"}
+  ],
+  "akpark": [
+    {"date": "2024-01-01", "visitors": 60, "revenue": 25000, "deals": 15, "rpv": 417, "admin": "Игорь"},
+    {"date": "2024-01-02", "visitors": 65, "revenue": 27000, "deals": 18, "rpv": 415, "admin": "Ксения"}
+  ]
+}

--- a/tests/test_salon_analytics.py
+++ b/tests/test_salon_analytics.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.services.analytics import AnalyticsService
+from app import config
+
+
+def test_get_salon_analytics(tmp_path, monkeypatch):
+    file = tmp_path / "salon.json"
+    sample = {
+        "mercury": [
+            {
+                "date": "2024-01-01",
+                "visitors": 10,
+                "revenue": 100,
+                "deals": 2,
+                "rpv": 10,
+                "admin": "A",
+            }
+        ]
+    }
+    file.write_text(json.dumps(sample), encoding="utf-8")
+    monkeypatch.setattr(config, "SALON_ANALYTICS_FILE", str(file))
+    from app.services import analytics
+    monkeypatch.setattr(analytics, "SALON_ANALYTICS_FILE", str(file))
+
+    svc = AnalyticsService()
+    data = asyncio.run(svc.get_salon_analytics("mercury"))
+    assert len(data) == 1
+    assert data[0]["visitors"] == 10


### PR DESCRIPTION
## Summary
- add "Analytics by salons" page with clickable salon blocks and data table
- expose backend endpoint and config for salon analytics data
- make Firebird service optional when `fdb` is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 2 errors, 8 warnings)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b1bb73f28832994775ca8bce09f6d