### PR TITLE
fix: read payout statuses from file

### DIFF
--- a/REF/components/admin/AdminPanel.tsx
+++ b/REF/components/admin/AdminPanel.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Badge } from '../ui/badge';
-import { StatusBadge } from '../design-system/StatusBadge';
+import { StatusBadge, StatusBadgeProps } from '../design-system/StatusBadge';
 import { ActionCard } from '../design-system/ActionCard';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Calendar } from '../ui/calendar';
@@ -590,11 +590,40 @@ const BonusesAndPenalties: React.FC = () => {
 
 // Управление выплатами
 const PaymentsManagement: React.FC = () => {
-  const payments = [
-    { id: 1, employee: 'Алексей Иванов', type: 'Аванс', amount: 15000, status: 'waiting' as const, date: '2025-07-25', store: 'ТЦ Мега' },
-    { id: 2, employee: 'Мария Петрова', type: 'Зарплата', amount: 35000, status: 'approved' as const, date: '2025-07-24', store: 'ТЦ Европолис' },
-    { id: 3, employee: 'Дмитрий Сидоров', type: 'Премия', amount: 8000, status: 'rejected' as const, date: '2025-07-23', store: 'ТЦ Атлас' }
-  ];
+  const [payments, setPayments] = useState<Array<{
+    id: number | string;
+    employee: string;
+    type: string;
+    amount: number;
+    status: StatusBadgeProps['status'];
+    date?: string;
+    store?: string;
+  }>>([]);
+
+  const STATUS_MAP: Record<string, StatusBadgeProps['status']> = {
+    'Ожидает': 'waiting',
+    'Одобрено': 'approved',
+    'Отклонено': 'rejected',
+    'Выплачено': 'paid'
+  };
+
+  useEffect(() => {
+    fetch('/advance_requests.json')
+      .then((res) => res.json())
+      .then((data) => {
+        const mapped = data.map((p: any) => ({
+          id: p.id,
+          employee: p.name,
+          type: p.payout_type,
+          amount: p.amount,
+          status: STATUS_MAP[p.status] || 'waiting',
+          date: p.timestamp,
+          store: p.method
+        }));
+        setPayments(mapped);
+      })
+      .catch((err) => console.error('Failed to load payouts', err));
+  }, []);
 
   return (
     <div className="space-y-6">

--- a/REF/components/design-system/StatusBadge.tsx
+++ b/REF/components/design-system/StatusBadge.tsx
@@ -3,7 +3,14 @@ import { Badge } from '../ui/badge';
 import { cn } from '../ui/utils';
 
 export interface StatusBadgeProps {
-  status: 'approved' | 'rejected' | 'waiting' | 'active' | 'inactive' | 'processing';
+  status:
+    | 'approved'
+    | 'rejected'
+    | 'waiting'
+    | 'active'
+    | 'inactive'
+    | 'processing'
+    | 'paid';
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'outline';
 }
@@ -38,6 +45,11 @@ const statusConfig = {
     label: 'Обработка',
     className: 'bg-primary text-primary-foreground border-primary',
     emoji: '🔄'
+  },
+  paid: {
+    label: 'Выплачено',
+    className: 'bg-primary text-primary-foreground border-primary',
+    emoji: '📤'
   },
 };
 


### PR DESCRIPTION
## Summary
- load payouts from advance_requests.json in admin panel
- map Russian payout statuses to internal badge values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac78a43dc88329ae3aa1577a4419fa