### PR TITLE
Add packaging metadata for Python distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include app/templates *.html

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project provides a Telegram bot with a FastAPI based HTTP API. The server c
 
 ## Installation
 
+### From source
+
 1. Create a virtual environment and install the dependencies:
 
 ```bash
@@ -27,6 +29,39 @@ pip install -r requirements.txt
 - `ADMIN_ID`, `ADMIN_CHAT_ID` – Telegram identifiers for the administrator
 
 If no configuration is provided, default values will be used and the project will look for JSON files such as `user.json`, `advance_requests.json`, `vacations.json` and others located in the repository root.
+
+### As an installable package
+
+The repository ships a standard Python package declaration in `pyproject.toml`. You can install the bot directly from GitHub via pip:
+
+```bash
+pip install git+https://github.com/your-account/bot.git
+```
+
+The installation exposes two entry points:
+
+* `telegram-salary-bot` – starts the Telegram bot in polling mode (equivalent to `python -m app.main`).
+* `telegram-salary-bot-api` – launches the FastAPI application via Uvicorn (equivalent to `python -m app`).
+
+To build distributable artifacts locally run:
+
+```bash
+python -m build
+```
+
+This command generates `.whl` and `.tar.gz` files under the `dist/` directory that can be published to PyPI or GitHub Packages. When targeting GitHub Packages make sure to:
+
+1. Create a Personal Access Token with the `write:packages` and `read:packages` scopes.
+2. Configure `~/.pypirc` with a section that points to the GitHub Packages upload endpoint and uses the generated token as the password. GitHub's documentation contains a ready-to-use template.
+3. Upload the build using `twine upload --repository <section-name> dist/*`.
+
+Once published, machines with access to the registry can install the package with:
+
+```bash
+pip install --extra-index-url https://pip.pkg.github.com/<OWNER> telegram-salary-bot
+```
+
+Replace `<OWNER>` with your GitHub username or organization.
 
 ## Running the FastAPI server
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,5 @@
-"""Application package."""
+"""Application package for the Telegram salary bot."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,5 +1,23 @@
+"""Console script for launching the HTTP API with Uvicorn."""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
 import uvicorn
+
+DEFAULT_HOST: Final[str] = "0.0.0.0"
+DEFAULT_PORT: Final[int] = 8000
+
+
+def main() -> None:
+    """Run the FastAPI application with Uvicorn."""
+
+    host = os.getenv("TELEGRAM_BOT_HOST", DEFAULT_HOST)
+    port = int(os.getenv("TELEGRAM_BOT_PORT", str(DEFAULT_PORT)))
+    uvicorn.run("app.server:app", host=host, port=port)
 
 
 if __name__ == "__main__":
-    uvicorn.run("app.server:app", host="0.0.0.0", port=8000)
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "telegram-salary-bot"
+version = "0.1.0"
+description = "Telegram bot and FastAPI backend for managing employee payouts and schedules."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Your Team" }]
+license = { text = "Proprietary" }
+keywords = ["telegram", "fastapi", "bot", "employees", "payouts"]
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "python-telegram-bot>=20",
+    "pandas",
+    "openpyxl",
+    "fpdf",
+    "pillow",
+    "reportlab",
+    "python-dateutil",
+    "pydantic",
+    "pydantic-settings",
+    "sqlalchemy",
+    "jinja2",
+    "numpy",
+    "python-multipart",
+]
+
+[project.scripts]
+telegram-salary-bot = "app.main:main"
+telegram-salary-bot-api = "app.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/your-account/bot"
+
+[tool.setuptools]
+packages = { find = { include = ["app", "app.*"] } }
+include-package-data = true
+
+[tool.setuptools.package-data]
+"app" = ["templates/**/*.html"]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` and manifest so the Telegram bot can be built and published as a Python package
- expose console entry points for running the bot and API from an installed distribution
- document package installation and publishing steps in the README

## Testing
- python -m build
- pytest *(fails: ModuleNotFoundError: No module named 'fdb')*


------
https://chatgpt.com/codex/tasks/task_e_6904b8a4ab3483298bd5316550757299