### PR TITLE
Track message acceptance timestamps

### DIFF
--- a/admin_frontend/src/pages/MessageHistory.jsx
+++ b/admin_frontend/src/pages/MessageHistory.jsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { MessageCircle, Users, AlertCircle, Clock, RefreshCcw, Trash2 } from 'lucide-react';
+import {
+  MessageCircle,
+  Users,
+  AlertCircle,
+  Clock,
+  RefreshCcw,
+  Trash2,
+  CheckCircle2,
+  Hourglass,
+} from 'lucide-react';
 import api from '../api';
 
 const typeFilters = [
@@ -207,10 +216,28 @@ export default function MessageHistory() {
                       Требуется подтверждение
                     </span>
                   )}
+                  {entry.accepted && (
+                    <span className="flex items-center gap-1 rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                      <CheckCircle2 size={14} />
+                      Принято
+                    </span>
+                  )}
+                  {entry.requires_ack && !entry.accepted && (
+                    <span className="flex items-center gap-1 rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
+                      <Hourglass size={14} />
+                      Ожидает подтверждения
+                    </span>
+                  )}
                   {entry.user_id && !entry.broadcast && (
                     <span className="text-xs text-gray-500">ID получателя: {entry.user_id}</span>
                   )}
                 </div>
+                {entry.accepted && entry.timestamp_accept && (
+                  <div className="flex items-center gap-2 text-xs text-green-600">
+                    <Clock size={14} />
+                    Подтверждено: {new Date(entry.timestamp_accept).toLocaleString()}
+                  </div>
+                )}
               </div>
               <div className="flex flex-col items-end gap-2">
                 <span className="text-xs uppercase tracking-wide text-gray-400">

--- a/admin_frontend/src/pages/Payouts.jsx
+++ b/admin_frontend/src/pages/Payouts.jsx
@@ -6,6 +6,9 @@ import {
   RefreshCw,
   Trash2,
   XCircle,
+  CheckCircle2,
+  Clock,
+  Hourglass,
 } from 'lucide-react';
 import api from '../api';
 
@@ -73,9 +76,31 @@ function MessageHistory() {
               ) : (
                 <tr key={m.id}>
                   <td className="px-2 py-1">{m.user_id}</td>
-                  <td className="px-2 py-1 whitespace-pre-wrap">{m.message}</td>
-                  <td className="px-2 py-1 text-xs">
-                    {m.timestamp && new Date(m.timestamp).toLocaleString()}
+                  <td className="px-2 py-1 whitespace-pre-wrap">
+                    <div>{m.message}</div>
+                    {m.requires_ack && !m.accepted && (
+                      <div className="mt-1 flex items-center gap-1 text-xs text-yellow-700">
+                        <Hourglass size={14} />
+                        Требуется подтверждение
+                      </div>
+                    )}
+                    {m.accepted && (
+                      <div className="mt-1 flex items-center gap-1 text-xs text-green-700">
+                        <CheckCircle2 size={14} />
+                        Принято
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-2 py-1 text-xs space-y-1">
+                    <div>
+                      {m.timestamp && new Date(m.timestamp).toLocaleString()}
+                    </div>
+                    {m.accepted && m.timestamp_accept && (
+                      <div className="flex items-center gap-1 text-green-600">
+                        <Clock size={14} />
+                        {new Date(m.timestamp_accept).toLocaleString()}
+                      </div>
+                    )}
                   </td>
                   <td className="px-2 py-1">
                     <button

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -45,3 +45,5 @@ class SentMessage(BaseModel):
     requires_ack: bool = False
     broadcast: bool = False
     recipients: Optional[list[dict]] = None
+    accepted: bool = False
+    timestamp_accept: Optional[str] = None

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -94,12 +94,19 @@ class TelegramService:
             data = json.loads(log_file.read_text(encoding="utf-8"))
         except Exception:
             return
+        accepted_at = None
+        normalized_status = status.lower() if isinstance(status, str) else ""
+        if "принят" in normalized_status:
+            accepted_at = datetime.utcnow().isoformat()
         for item in data:
             if (
                 str(item.get("user_id")) == str(user_id)
                 and item.get("message_id") == message_id
             ):
                 item["status"] = status
+                if accepted_at:
+                    item["accepted"] = True
+                    item["timestamp_accept"] = accepted_at
                 break
         log_file.write_text(
             json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
@@ -239,6 +246,8 @@ class TelegramService:
             "timestamp": datetime.utcnow().isoformat(),
             "photo_url": photo_url,
             "requires_ack": require_ack,
+            "accepted": False,
+            "timestamp_accept": None,
         }
         data = self._load_log_all()
         data.append(log_entry)


### PR DESCRIPTION
## Summary
- log direct Telegram messages with acceptance metadata for history endpoints
- expose acceptance flags in SentMessage API responses and surface them in the admin UI
- highlight confirmation status and timestamp inside message history views

## Testing
- pytest *(fails: missing optional dependency `fdb`)*

------
https://chatgpt.com/codex/tasks/task_e_6904c1440e9c832985afb4c7e8229bdd