### PR TITLE
Fix login redirect paths for admin SPA

### DIFF
--- a/admin_frontend/src/api.js
+++ b/admin_frontend/src/api.js
@@ -22,8 +22,9 @@ api.interceptors.response.use(
     console.error('API', error.config?.url, error.message);
     if (error.response?.status === 401) {
       localStorage.removeItem('auth_token');
-      if (!window.location.pathname.startsWith('/login')) {
-        window.location.href = '/login';
+      const loginPath = '/admin/login';
+      if (!window.location.pathname.startsWith(loginPath)) {
+        window.location.href = loginPath;
       }
     }
     return Promise.reject(error);

--- a/admin_frontend/src/pages/Login.jsx
+++ b/admin_frontend/src/pages/Login.jsx
@@ -6,7 +6,7 @@ export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname || '/admin';
+  const from = location.state?.from?.pathname || '/';
 
   const [form, setForm] = useState({ login: '', password: '' });
   const [error, setError] = useState('');


### PR DESCRIPTION
## Summary
- update the 401 interceptor to send users back to /admin/login so the admin SPA can load again
- adjust the login page fallback redirect to the dashboard route so successful logins land on a valid path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69088b44df7083299e638e0af2bd93b9