### PR TITLE
fix: исправить глобальные стили Tailwind

### DIFF
--- a/admin_frontend/src/styles/globals.css
+++ b/admin_frontend/src/styles/globals.css
@@ -800,63 +800,60 @@ tbody tr:last-child td {
   }
 
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--color-bg);
+    color: var(--color-text);
   }
 }
 
 /**
  * Base typography. This is not applied to elements which have an ancestor with a Tailwind text class.
  */
-@layer base {
-  :where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) {
-    h1 {
-      font-size: var(--text-2xl);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h1 {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h2 {
-      font-size: var(--text-xl);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h2 {
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h3 {
-      font-size: var(--text-lg);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h3 {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h4 {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h4 {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    p {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-normal);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) p {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.5;
+}
 
-    label {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) label {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    button {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) button {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    input {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-normal);
-      line-height: 1.5;
-    }
-  }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) input {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.5;
 }
 
 html {


### PR DESCRIPTION
## Summary
- заменить недоступный tailwind-утилити-класс на прямые CSS-переменные для мобильного оформления
- переписать блок базовой типографики без Tailwind- и nesting-конструкций, чтобы избежать ошибок postcss

## Testing
- npm run build *(fails: vite: Permission denied из-за Windows-ориентированных бинарников в репозитории)*

------
https://chatgpt.com/codex/tasks/task_b_690b270fb8a48323a3579c1a2b8e92b8