### PR TITLE
feat: route card payouts to user chats

### DIFF
--- a/admin_frontend/src/styles/globals.css
+++ b/admin_frontend/src/styles/globals.css
@@ -800,63 +800,60 @@ tbody tr:last-child td {
   }
 
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--color-bg);
+    color: var(--color-text);
   }
 }
 
 /**
  * Base typography. This is not applied to elements which have an ancestor with a Tailwind text class.
  */
-@layer base {
-  :where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) {
-    h1 {
-      font-size: var(--text-2xl);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h1 {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h2 {
-      font-size: var(--text-xl);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h2 {
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h3 {
-      font-size: var(--text-lg);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h3 {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    h4 {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) h4 {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    p {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-normal);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) p {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.5;
+}
 
-    label {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) label {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    button {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.5;
-    }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) button {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.5;
+}
 
-    input {
-      font-size: var(--text-base);
-      font-weight: var(--font-weight-normal);
-      line-height: 1.5;
-    }
-  }
+:where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) input {
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.5;
 }
 
 html {

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any, Iterable
 
 from .settings import Settings
 
@@ -11,6 +12,45 @@ def _load_settings() -> Settings:
         data = json.loads(path.read_text(encoding="utf-8"))
     allowed = {k: v for k, v in data.items() if k in Settings.__annotations__}
     return Settings(**allowed)
+
+
+def _normalize_card_dispatch_chats(
+    raw_chats: Iterable[dict[str, Any]] | None,
+    fallback_chat_id: int | None,
+) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    if raw_chats:
+        for idx, entry in enumerate(raw_chats, start=1):
+            if not isinstance(entry, dict):
+                continue
+            chat_id = entry.get("chat_id")
+            try:
+                chat_id_int = int(chat_id)
+            except (TypeError, ValueError):
+                continue
+            key = entry.get("key") or entry.get("id") or f"chat_{idx}"
+            name = entry.get("name") or f"Кассир {idx}"
+            normalized.append(
+                {
+                    "key": str(key),
+                    "name": str(name),
+                    "chat_id": chat_id_int,
+                }
+            )
+    if not normalized and fallback_chat_id:
+        try:
+            chat_id_int = int(fallback_chat_id)
+        except (TypeError, ValueError):
+            chat_id_int = None
+        if chat_id_int:
+            normalized.append(
+                {
+                    "key": "default",
+                    "name": "Основной кассир",
+                    "chat_id": chat_id_int,
+                }
+            )
+    return normalized
 
 
 settings = _load_settings()
@@ -31,5 +71,13 @@ USER_LOGIN = settings.user_login
 USER_PASSWORD = settings.user_password
 FONT_PATH = settings.font_path
 MAX_ADVANCE_AMOUNT_PER_MONTH = settings.max_advance_amount_per_month
-CARD_DISPATCH_CHAT_ID = settings.card_dispatch_chat_id
+CARD_DISPATCH_CHATS = _normalize_card_dispatch_chats(
+    settings.card_dispatch_chats, settings.card_dispatch_chat_id
+)
+CARD_DISPATCH_CHAT_ID = (
+    CARD_DISPATCH_CHATS[0]["chat_id"] if CARD_DISPATCH_CHATS else settings.card_dispatch_chat_id
+)
+DEFAULT_CARD_DISPATCH_CHAT_KEY = (
+    CARD_DISPATCH_CHATS[0]["key"] if CARD_DISPATCH_CHATS else None
+)
 SECRET_KEY = settings.secret_key

--- a/app/core/types.py
+++ b/app/core/types.py
@@ -28,3 +28,4 @@ class Employee:
     status: EmployeeStatus = EmployeeStatus.ACTIVE
     created_at: datetime = field(default_factory=datetime.utcnow)
     tags: List[str] = field(default_factory=list)
+    payout_chat_key: Optional[str] = None

--- a/app/data/employee_repository.py
+++ b/app/data/employee_repository.py
@@ -56,6 +56,7 @@ class EmployeeRepository:
             "created_at": self._parse_datetime(data.get("created_at"))
             or datetime.utcnow(),
             "tags": data.get("tags", []),
+            "payout_chat_key": data.get("payout_chat_key"),
         }
         return Employee(**record)
 

--- a/app/schemas/employee.py
+++ b/app/schemas/employee.py
@@ -18,6 +18,7 @@ class EmployeeBase(BaseModel):
     note: Optional[str] = ""
     photo_url: Optional[str] = ""
     status: str = "active"
+    payout_chat_key: Optional[str] = None
 
 
 class EmployeeCreate(EmployeeBase):
@@ -45,3 +46,4 @@ class Employee(BaseModel):
     is_admin: bool = False
     note: Optional[str] = None
     photo_url: Optional[str] = None
+    payout_chat_key: Optional[str] = None

--- a/app/services/employee_service.py
+++ b/app/services/employee_service.py
@@ -50,7 +50,7 @@ class EmployeeService:
             return None
         new_id = updates.pop("id", None)
         for key, value in updates.items():
-            if hasattr(emp, key) and value is not None:
+            if hasattr(emp, key):
                 setattr(emp, key, value)
         if new_id and new_id != emp.id:
             if any(e.id == str(new_id) for e in self._employees):
@@ -101,6 +101,7 @@ class EmployeeAPIService:
             note=data.note or "",
             photo_url=data.photo_url or "",
             status=EmployeeStatus(data.status or "active"),
+            payout_chat_key=data.payout_chat_key,
         )
         try:
             created = self.service.add_employee(employee)

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -28,6 +28,7 @@ def load_users() -> List[Dict[str, Any]]:
                 "note": emp.note,
                 "photo_url": emp.photo_url,
                 "status": emp.status.value,
+                "payout_chat_key": getattr(emp, "payout_chat_key", None),
             }
         )
     log(f"✅ Загружено сотрудников: {len(result)}")
@@ -57,9 +58,11 @@ def save_users(users: Dict[str, Any]) -> None:
                 note=data.get("note", ""),
                 photo_url=data.get("photo_url", ""),
                 status=EmployeeStatus(data.get("status", "active")),
+                payout_chat_key=data.get("payout_chat_key"),
             )
         )
     _repo.save_employees(employees)
+
 def add_user(user_id: str, user_data: Dict[str, Any]) -> None:
     employee = Employee(
         id=str(user_id),
@@ -74,6 +77,7 @@ def add_user(user_id: str, user_data: Dict[str, Any]) -> None:
         note=user_data.get("note", ""),
         photo_url=user_data.get("photo_url", ""),
         status=EmployeeStatus(user_data.get("status", "active")),
+        payout_chat_key=user_data.get("payout_chat_key"),
     )
     _repo.add_employee(employee)
 
@@ -97,6 +101,7 @@ def update_user(user_id: str, fields: Dict[str, Any]) -> None:
         note=emp_dict.get("note", ""),
         photo_url=emp_dict.get("photo_url", ""),
         status=EmployeeStatus(emp_dict.get("status", "active")),
+        payout_chat_key=emp_dict.get("payout_chat_key"),
     )
     _repo.update_employee(employee)
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import JsonConfigSettingsSource
@@ -41,6 +43,9 @@ class Settings(BaseSettings):
     font_path: str = Field("fonts/DejaVuSans.ttf", validation_alias="FONT_PATH")
     card_dispatch_chat_id: int = Field(
         -1002667932339, validation_alias="CARD_DISPATCH_CHAT_ID"
+    )
+    card_dispatch_chats: list[dict[str, Any]] = Field(
+        default_factory=list, validation_alias="CARD_DISPATCH_CHATS"
     )
     max_advance_amount_per_month: int = Field(
         500000000,


### PR DESCRIPTION
## Summary
- add support for configuring named кассир chats and expose them via settings
- allow сохранять выбранный чат кассира на карточке сотрудника в API и UI админки
- перенаправлять подтверждённые выплаты "На карту" в персональный чат кассира и отображать выбор в истории

## Testing
- npm run build *(fails: Permission denied for vite binary in tracked node_modules)*

------
https://chatgpt.com/codex/tasks/task_b_690b270fb8a48323a3579c1a2b8e92b8