### PR TITLE
Enable authorized payout date management

### DIFF
--- a/app/schemas/payout.py
+++ b/app/schemas/payout.py
@@ -29,6 +29,7 @@ class PayoutCreate(BaseModel):
     sync_to_bot: bool = False
     note: Optional[str] = None
     show_note_in_bot: bool = False
+    timestamp: Optional[datetime] = None
 
 
 class PayoutUpdate(BaseModel):
@@ -43,6 +44,7 @@ class PayoutUpdate(BaseModel):
     notify_user: Optional[bool] = None
     note: Optional[str] = None
     show_note_in_bot: Optional[bool] = None
+    timestamp: Optional[datetime] = None
 
 
 class PayoutControlItem(BaseModel):

--- a/app/services/access_control_service.py
+++ b/app/services/access_control_service.py
@@ -18,6 +18,10 @@ AVAILABLE_PERMISSIONS: list[dict[str, str]] = [
     {"id": "dashboard", "label": "Дашборд"},
     {"id": "employees", "label": "Сотрудники"},
     {"id": "payouts", "label": "Выплаты"},
+    {
+        "id": "payouts-manage-dates",
+        "label": "Выплаты: изменять дату и создавать задним числом",
+    },
     {"id": "payouts-control", "label": "Контроль выплат"},
     {"id": "incentives", "label": "Штрафы и премии"},
     {"id": "reports", "label": "Отчёты"},
@@ -288,6 +292,10 @@ class AccessControlService:
 
     def available_bot_buttons(self) -> list[dict[str, Any]]:
         return BOT_BUTTON_CATALOG
+
+    def user_has_permission(self, user: ResolvedUser, permission: str) -> bool:
+        permissions = user.permissions or []
+        return "*" in permissions or permission in permissions
 
     def create_role(self, data: dict[str, Any]) -> dict[str, Any]:
         role_id = data.get("id") or secrets.token_hex(6)


### PR DESCRIPTION
## Summary
- add a dedicated permission for managing payout dates and expose it in the access control catalog
- allow the payouts API and service layer to accept custom timestamps when the caller has that permission
- surface a datetime field in the payouts UI for permitted users and normalize submitted timestamps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690ca69a0eb483239d00018b4351fe19