### PR TITLE
Add .input-field styling to match input control styles

### DIFF
--- a/admin_frontend/src/styles/globals.css
+++ b/admin_frontend/src/styles/globals.css
@@ -332,6 +332,7 @@ a:hover { text-decoration: underline; }
    Inputs / Controls
    ================================================================ */
 .input,
+.input-field,
 .modal-control,
 .form-field input,
 .form-field select,
@@ -347,6 +348,7 @@ a:hover { text-decoration: underline; }
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
 }
 .input:focus,
+.input-field:focus,
 .modal-control:focus,
 .form-field input:focus,
 .form-field select:focus,
@@ -357,6 +359,7 @@ a:hover { text-decoration: underline; }
   background: var(--color-control-bg-hover);
 }
 .input::placeholder,
+.input-field::placeholder,
 .modal-control::placeholder { color: var(--color-control-placeholder); }
 .form-field textarea { resize: vertical; min-height: 100px; }
 


### PR DESCRIPTION
## Summary
Extended the input control styling rules to include the `.input-field` class, ensuring consistent appearance and behavior across all input-related elements in the admin frontend.

## Key Changes
- Added `.input-field` selector to the base input styling rule (line 335)
- Added `.input-field:focus` selector to the focus state styling (line 351)
- Added `.input-field::placeholder` selector to the placeholder color styling (line 361)

## Implementation Details
The `.input-field` class now inherits all the same styling properties as `.input`, including:
- Border color, box-shadow, and background transitions
- Focus state styling with updated border color, box-shadow, and background
- Placeholder text color

This ensures visual and behavioral consistency between elements using the `.input` class and those using the `.input-field` class.

https://claude.ai/code/session_01VMXdpUievJ96FvJUkZ4Xqj